### PR TITLE
refactor: remove explicitly named libraries

### DIFF
--- a/very_good_dart_cli/__brick__/{{project_name.snakeCase()}}/lib/{{project_name.snakeCase()}}.dart
+++ b/very_good_dart_cli/__brick__/{{project_name.snakeCase()}}/lib/{{project_name.snakeCase()}}.dart
@@ -7,4 +7,4 @@
 /// # see usage
 /// {{executable_name.snakeCase()}} --help
 /// ```
-library {{project_name.snakeCase()}};
+library;

--- a/very_good_dart_cli/__brick__/{{project_name.snakeCase()}}/test/ensure_build_test.dart
+++ b/very_good_dart_cli/__brick__/{{project_name.snakeCase()}}/test/ensure_build_test.dart
@@ -1,5 +1,5 @@
 @Tags(['version-verify'])
-library ensure_build_test;
+library;
 
 import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart';

--- a/very_good_dart_package/__brick__/{{project_name.snakeCase()}}/lib/{{project_name.snakeCase()}}.dart
+++ b/very_good_dart_package/__brick__/{{project_name.snakeCase()}}/lib/{{project_name.snakeCase()}}.dart
@@ -1,4 +1,4 @@
 /// {{{description}}}
-library {{project_name.snakeCase()}};
+library;
 
 export 'src/{{project_name.snakeCase()}}.dart';

--- a/very_good_flutter_package/__brick__/{{project_name.snakeCase()}}/lib/{{project_name.snakeCase()}}.dart
+++ b/very_good_flutter_package/__brick__/{{project_name.snakeCase()}}/lib/{{project_name.snakeCase()}}.dart
@@ -1,4 +1,4 @@
 /// {{{description}}}
-library {{project_name.snakeCase()}};
+library;
 
 export 'src/{{project_name.snakeCase()}}.dart';

--- a/very_good_flutter_plugin/hooks/lib/src/cli/cli.dart
+++ b/very_good_flutter_plugin/hooks/lib/src/cli/cli.dart
@@ -1,7 +1,7 @@
 /// Collection of command line interfaces (CLIs).
 ///
 /// This library abstracts some CLIs to facilitate interacting with them.
-library cli;
+library;
 
 export 'command_line.dart';
 export 'dart_cli.dart';

--- a/very_good_flutter_plugin/hooks/lib/version.dart
+++ b/very_good_flutter_plugin/hooks/lib/version.dart
@@ -2,7 +2,7 @@
 ///
 /// This file is not automatically generated. It is manually maintained and
 /// should be updated when the template requires to be updated.
-library version;
+library;
 
 /// The version of the template.
 const $templateVersion = '0.7.0';

--- a/very_good_flutter_plugin/hooks/lib/very_good_flutter_plugin_hooks.dart
+++ b/very_good_flutter_plugin/hooks/lib/very_good_flutter_plugin_hooks.dart
@@ -1,2 +1,2 @@
 /// Mason hooks for the Very Good Flutter Plugin brick.
-library very_good_flutter_plugin_hooks;
+library;

--- a/very_good_flutter_plugin/tool/merge_coverage/merge_coverage.dart
+++ b/very_good_flutter_plugin/tool/merge_coverage/merge_coverage.dart
@@ -6,7 +6,7 @@
 ///
 /// Should be removed once the following Very Good CLI issue is resolved:
 /// https://github.com/VeryGoodOpenSource/very_good_cli/issues/804
-library merge_coverage;
+library;
 
 import 'dart:io';
 


### PR DESCRIPTION
## Description

Removing named library from packages to adhere to [effective dart guidelines](https://dart.dev/effective-dart/style#dont-explicitly-name-libraries)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ X] 🗑️ Chore
