### PR TITLE
chore(very_good_core): ensure template uses Flutter 3.22 with Dart 3.4

### DIFF
--- a/.github/workflows/very_good_core.yaml
+++ b/.github/workflows/very_good_core.yaml
@@ -31,7 +31,7 @@ jobs:
         flutter-version:
           # The version of Flutter to use should use the minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.19.0"
+          - "3.22.0"
           - "3.x"
 
     steps:

--- a/very_good_core/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_core/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ^3.4.1
+  sdk: ^3.4.0
 
 dependencies:
   bloc: ^8.1.3

--- a/very_good_core/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_core/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: "^3.3.0"
+  sdk: ^3.4.1
 
 dependencies:
   bloc: ^8.1.3
@@ -13,7 +13,7 @@ dependencies:
   flutter_bloc: ^8.1.4
   flutter_localizations:
     sdk: flutter
-  intl: ^0.18.1
+  intl: ^0.19.0
 
 dev_dependencies:
   bloc_test: ^9.1.6

--- a/very_good_core/hooks/pubspec.yaml
+++ b/very_good_core/hooks/pubspec.yaml
@@ -1,7 +1,7 @@
 name: very_good_core_hooks
 
 environment:
-  sdk: "^3.3.0"
+  sdk: ^3.4.0
 
 dependencies:
   mason: ^0.1.0-dev.52


### PR DESCRIPTION
## Description

Related to #96 

Updates the very_good_core template so it runs and uses on Flutter 3.22 with Dart 3.4. 

This change limits itself to make the project runnable. Amendments due to the new version (such as the serviceWorkerVersion warning, #98 ) are to be done in a follow-up pull requests. 

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
