### PR TITLE
chore(very_good_dart_package): ensure template uses Dart 3.4

### DIFF
--- a/.github/workflows/very_good_dart_package.yaml
+++ b/.github/workflows/very_good_dart_package.yaml
@@ -27,7 +27,7 @@ jobs:
         dart-version:
           # The minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.3.0"
+          - "3.4.0"
           - "stable"
 
     steps:

--- a/very_good_dart_package/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_dart_package/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: "^3.3.0"
+  sdk: ^3.4.0
 
 dev_dependencies:
   mocktail: ^1.0.3


### PR DESCRIPTION
## Description

Related to https://github.com/VeryGoodOpenSource/very_good_templates/issues/96

Updates the very_good_dart_package template so it runs and uses Dart 3.4.

This change limits itself to make the project runnable. Amendments due to the new language version should be considered in follow up pull requests.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
