### PR TITLE
chore(very_good_flutter_package): ensure template uses Flutter 3.22 with Dart 3.4

### DIFF
--- a/.github/workflows/very_good_flutter_package.yaml
+++ b/.github/workflows/very_good_flutter_package.yaml
@@ -27,7 +27,7 @@ jobs:
         flutter-version:
           # The version of Flutter to use should use the minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.19.0"
+          - "3.22.0"
           - "3.x"
 
     steps:

--- a/very_good_flutter_package/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_flutter_package/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0+1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: "^3.3.0"
-  flutter: "^3.19.0"
+  sdk: ^3.4.0
+  flutter: ^3.22.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

Related to https://github.com/VeryGoodOpenSource/very_good_templates/issues/96

Updates the very_good_flutter_package template so it runs and uses on Flutter 3.22 with Dart 3.4.

This change limits itself to make the project runnable. Amendments due to the new Flutter or Dart version are to be done in a follow-up pull requests.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
