### PR TITLE
chore(very_good_flame_game): ensure template uses Flutter 3.22 with Dart 3.4

### DIFF
--- a/.github/workflows/very_good_flame_game.yaml
+++ b/.github/workflows/very_good_flame_game.yaml
@@ -31,7 +31,7 @@ jobs:
         flutter-version:
           # The version of Flutter to use should use the minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.19.0"
+          - "3.22.0"
           - "3.x"
 
     steps:

--- a/very_good_flame_game/__brick__/{{project_name.snakeCase()}}/lib/app/view/app.dart
+++ b/very_good_flame_game/__brick__/{{project_name.snakeCase()}}/lib/app/view/app.dart
@@ -41,7 +41,7 @@ class AppView extends StatelessWidget {
         scaffoldBackgroundColor: const Color(0xFFFFFFFF),
         elevatedButtonTheme: ElevatedButtonThemeData(
           style: ButtonStyle(
-            backgroundColor: MaterialStateProperty.all(const Color(0xFF2A48DF)),
+            backgroundColor: WidgetStateProperty.all(const Color(0xFF2A48DF)),
           ),
         ),
         textTheme: GoogleFonts.poppinsTextTheme(),

--- a/very_good_flame_game/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_flame_game/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ^3.4.0
 
 dependencies:
   audioplayers: ^5.2.1
@@ -19,7 +19,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   google_fonts: ^6.1.0
-  intl: ^0.18.1
+  intl: ^0.19.0
 
 dev_dependencies:
   bloc_test: ^9.1.6


### PR DESCRIPTION
## Description

Related to https://github.com/VeryGoodOpenSource/very_good_templates/issues/96

Updates the very_good_flame_game template so it runs and uses on Flutter 3.22 with Dart 3.4.

This change limits itself to make the project runnable. Amendments due to the new version (such as the serviceWorkerVersion warning, see #103 ) are to be done in a follow-up pull requests.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
