### PR TITLE
chore(very_good_wear_app): ensure template uses Flutter 3.22 with Dart 3.4

### DIFF
--- a/.github/workflows/very_good_wear_app.yaml
+++ b/.github/workflows/very_good_wear_app.yaml
@@ -27,7 +27,7 @@ jobs:
         flutter-version:
           # The version of Flutter to use should use the minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.19.0"
+          - "3.22.0"
           - "3.x"
 
     steps:

--- a/very_good_wear_app/__brick__/{{project_name.snakeCase()}}/lib/app/view/app.dart
+++ b/very_good_wear_app/__brick__/{{project_name.snakeCase()}}/lib/app/view/app.dart
@@ -22,7 +22,6 @@ class App extends StatelessWidget {
             colorScheme: isAmbientModeActive
                 ? const ColorScheme.dark(
                     primary: Colors.white24,
-                    onBackground: Colors.white10,
                     onSurface: Colors.white10,
                   )
                 : const ColorScheme.dark(

--- a/very_good_wear_app/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_wear_app/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: "^3.3.0"
+  sdk: ^3.4.0
 
 dependencies:
   bloc: ^8.1.3
@@ -13,7 +13,7 @@ dependencies:
   flutter_bloc: ^8.1.4
   flutter_localizations:
     sdk: flutter
-  intl: ^0.18.1
+  intl: ^0.19.0
   wearable_rotary: ^2.0.2
 
 dev_dependencies:

--- a/very_good_wear_app/__brick__/{{project_name.snakeCase()}}/test/app/view/app_test.dart
+++ b/very_good_wear_app/__brick__/{{project_name.snakeCase()}}/test/app/view/app_test.dart
@@ -40,7 +40,6 @@ void main() {
           getMaterialApp().theme?.colorScheme,
           const ColorScheme.dark(
             primary: Colors.white24,
-            onBackground: Colors.white10,
             onSurface: Colors.white10,
           ),
         );

--- a/very_good_wear_app/hooks/pubspec.yaml
+++ b/very_good_wear_app/hooks/pubspec.yaml
@@ -1,7 +1,7 @@
 name: very_good_wear_app_hooks
 
 environment:
-  sdk: "^3.3.0"
+  sdk: ^3.4.0
 
 dependencies:
   mason: ^0.1.0-dev.52


### PR DESCRIPTION
## Description

Related to https://github.com/VeryGoodOpenSource/very_good_templates/issues/96

Updates the very_good_wear_app template so it runs and uses on Flutter 3.22 with Dart 3.4.

This change limits itself to make the project runnable. Amendments due to the new Flutter or Dart version are to be done in a follow-up pull requests.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
