### PR TITLE
chore(very_good_flutter_plugin): ensure template uses Flutter 3.22 with Dart 3.4

### DIFF
--- a/.github/workflows/very_good_flutter_plugin.yaml
+++ b/.github/workflows/very_good_flutter_plugin.yaml
@@ -27,7 +27,7 @@ jobs:
         flutter-version:
           # The version of Flutter to use should use the minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.19.0"
+          - "3.22.0"
           - "3.x"
 
         platform:

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#android}}{{project_name.snakeCase()}}_android{{/android}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#android}}{{project_name.snakeCase()}}_android{{/android}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: "{{{dartSdkVersionBounds}}}"
+  sdk: {{{dartSdkVersionBounds}}}
 
 flutter:
   plugin:

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#ios}}{{project_name.snakeCase()}}_ios{{/ios}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#ios}}{{project_name.snakeCase()}}_ios{{/ios}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: "{{{dartSdkVersionBounds}}}"
+  sdk: {{{dartSdkVersionBounds}}}
 
 flutter:
   plugin:

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#linux}}{{project_name.snakeCase()}}_linux{{/linux}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#linux}}{{project_name.snakeCase()}}_linux{{/linux}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: "{{{dartSdkVersionBounds}}}"
+  sdk: {{{dartSdkVersionBounds}}}
 
 flutter:
   plugin:

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#macos}}{{project_name.snakeCase()}}_macos{{/macos}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#macos}}{{project_name.snakeCase()}}_macos{{/macos}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: "{{{dartSdkVersionBounds}}}"
+  sdk: {{{dartSdkVersionBounds}}}
 
 flutter:
   plugin:

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#web}}{{project_name.snakeCase()}}_web{{/web}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#web}}{{project_name.snakeCase()}}_web{{/web}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: "{{{dartSdkVersionBounds}}}"
+  sdk: {{{dartSdkVersionBounds}}}
 
 flutter:
   plugin:

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#windows}}{{project_name.snakeCase()}}_windows{{/windows}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#windows}}{{project_name.snakeCase()}}_windows{{/windows}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: "{{{dartSdkVersionBounds}}}"
+  sdk: {{{dartSdkVersionBounds}}}
 
 flutter:
   plugin:

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/actions/check_platform_name/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/actions/check_platform_name/pubspec.yaml
@@ -3,7 +3,7 @@ description: A custom action for Fluttium.
 version: 0.1.0+1
 
 environment:
-  sdk: "{{{dartSdkVersionBounds}}}"
+  sdk: {{{dartSdkVersionBounds}}}
 
 dependencies:
   flutter:

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: "{{{dartSdkVersionBounds}}}"
+  sdk: {{{dartSdkVersionBounds}}}
 
 dependencies:
   flutter:

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: "{{{dartSdkVersionBounds}}}"
+  sdk: {{{dartSdkVersionBounds}}}
 
 {{> plugin_platforms.dart }}
 

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}_platform_interface/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: "{{{dartSdkVersionBounds}}}"
+  sdk: {{{dartSdkVersionBounds}}}
 
 dependencies:
   flutter:

--- a/very_good_flutter_plugin/hooks/lib/version.dart
+++ b/very_good_flutter_plugin/hooks/lib/version.dart
@@ -8,7 +8,7 @@ library;
 const $templateVersion = '0.7.0';
 
 /// The Flutter version associated with the template version.
-const $flutterVersion = '3.19.0';
+const $flutterVersion = '3.22.0';
 
 /// The minimum Dart version required by the template.
 ///
@@ -18,4 +18,4 @@ const $flutterVersion = '3.19.0';
 /// See also:
 ///
 /// * [Flutter SDK archive](https://docs.flutter.dev/release/archive)
-const $minDartVersion = '3.3.0';
+const $minDartVersion = '3.4.0';

--- a/very_good_flutter_plugin/hooks/pubspec.yaml
+++ b/very_good_flutter_plugin/hooks/pubspec.yaml
@@ -1,7 +1,7 @@
 name: very_good_flutter_plugin_hooks
 
 environment:
-  sdk: "^3.3.0"
+  sdk: ^3.4.0
 
 dependencies:
   mason: ^0.1.0-dev.52


### PR DESCRIPTION
## Description

Related to https://github.com/VeryGoodOpenSource/very_good_templates/issues/96

Updates the very_good_flutter_plugin template so it runs and uses on Flutter 3.22 with Dart 3.4.

This change limits itself to make the project runnable. Amendments due to the new version are to be done in a follow-up pull requests.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
