### PR TITLE
style: Adding extra space to the application opening tag

### DIFF
--- a/very_good_core/__brick__/{{project_name.snakeCase()}}/android/app/src/main/AndroidManifest.xml
+++ b/very_good_core/__brick__/{{project_name.snakeCase()}}/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="{{org_name.dotCase()}}.{{project_name.snakeCase()}}">
-   <application
+    <application
         android:label="${appName}"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">

--- a/very_good_flame_game/__brick__/{{project_name.snakeCase()}}/android/app/src/main/AndroidManifest.xml
+++ b/very_good_flame_game/__brick__/{{project_name.snakeCase()}}/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="{{org_name.dotCase()}}.{{project_name.snakeCase()}}">
-   <application
+    <application
         android:label="${appName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/{{#android}}android{{/android}}/app/src/main/AndroidManifest.xml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/{{#android}}android{{/android}}/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="{{org_name.dotCase()}}.example">
-   <application
+    <application
         android:label="example"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">

--- a/very_good_wear_app/__brick__/{{project_name.snakeCase()}}/android/app/src/main/AndroidManifest.xml
+++ b/very_good_wear_app/__brick__/{{project_name.snakeCase()}}/android/app/src/main/AndroidManifest.xml
@@ -33,8 +33,8 @@
             android:name="flutterEmbedding"
             android:value="2" />
 
-       <meta-data
-           android:name="com.google.android.wearable.standalone"
-           android:value="true" />
+        <meta-data
+            android:name="com.google.android.wearable.standalone"
+            android:value="true" />
     </application>
 </manifest>


### PR DESCRIPTION
and wearable meta data in AndroidManifest.xml templates. Fixes #125

## Description

Discovered a missing space ahead of the `<application` in the AndroidManifest.xml. It affected creation of Flutter app (`create flutter_app`), and upon code inspection I also saw the same pattern in Flame Game and Flutter Plugin creation. Besides that towards the end of the Wear app creation manifest had missing single spaces for the `com.google.android.wearable.standalone` `meta-data` tag.

Ref https://github.com/VeryGoodOpenSource/very_good_cli/pull/1067 and https://github.com/VeryGoodOpenSource/very_good_cli/issues/1066

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
