### PR TITLE
feat: use application id on macOS project

### DIFF
--- a/very_good_core/__brick__/{{project_name.snakeCase()}}/macos/Runner.xcodeproj/project.pbxproj
+++ b/very_good_core/__brick__/{{project_name.snakeCase()}}/macos/Runner.xcodeproj/project.pbxproj
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/my_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/my_app";
@@ -398,7 +398,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/my_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/my_app";
@@ -412,7 +412,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/my_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/my_app";
@@ -720,7 +720,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.stg;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.stg;
 				PRODUCT_NAME = "$(FLAVOR_APP_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -735,7 +735,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/my_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/my_app";
@@ -818,7 +818,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.dev;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.dev;
 				PRODUCT_NAME = "$(FLAVOR_APP_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -833,7 +833,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/my_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/my_app";
@@ -909,7 +909,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.dev;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.dev;
 				PRODUCT_NAME = "$(FLAVOR_APP_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -923,7 +923,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/my_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/my_app";
@@ -999,7 +999,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.stg;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.stg;
 				PRODUCT_NAME = "$(FLAVOR_APP_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1013,7 +1013,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/my_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/my_app";
@@ -1089,7 +1089,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.dev;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.dev;
 				PRODUCT_NAME = "$(FLAVOR_APP_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1103,7 +1103,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/my_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/my_app";
@@ -1179,7 +1179,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.stg;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.stg;
 				PRODUCT_NAME = "$(FLAVOR_APP_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1193,7 +1193,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.myApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = {{macos_application_id}}.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/my_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/my_app";

--- a/very_good_core/hooks/lib/src/models/apple_application_id.dart
+++ b/very_good_core/hooks/lib/src/models/apple_application_id.dart
@@ -1,7 +1,7 @@
 import 'package:mason/mason.dart';
 
-/// {@template ios_application_id}
-/// An App ID identifies your iOS app in a provisioning profile.
+/// {@template apple_application_id}
+/// An App ID identifies your iOS/macOS app in a provisioning profile.
 ///
 /// An App ID is a two-part string used to identify one or more apps from a
 /// single development team. A period (.) separates its parts.
@@ -11,12 +11,12 @@ import 'package:mason/mason.dart';
 /// * [Register an App ID](https://developer.apple.com/help/account/manage-identifiers/register-an-app-id/)
 /// * [Apple Documentation Archive](https://developer.apple.com/library/archive/documentation/General/Conceptual/DevPedia-CocoaCore/AppID.html)
 /// {@endtemplate}
-extension type IosApplicationId(String value) {
-  /// Creates a new [IosApplicationId] from the provided [organizationName]
+extension type AppleApplicationId(String value) {
+  /// Creates a new [AppleApplicationId] from the provided [organizationName]
   /// and [projectName].
   ///
   /// This is the default fallback value for the application ID.
-  factory IosApplicationId.fallback({
+  factory AppleApplicationId.fallback({
     required String organizationName,
     required String projectName,
   }) {
@@ -27,6 +27,6 @@ extension type IosApplicationId(String value) {
     }
     parts.add(projectName.paramCase);
 
-    return IosApplicationId(parts.join('.'));
+    return AppleApplicationId(parts.join('.'));
   }
 }

--- a/very_good_core/hooks/lib/src/models/models.dart
+++ b/very_good_core/hooks/lib/src/models/models.dart
@@ -1,6 +1,6 @@
 export 'android_application_id.dart';
 export 'android_namespace.dart';
+export 'apple_application_id.dart';
 export 'exceptions.dart';
-export 'ios_application_id.dart';
 export 'very_good_core_configuration.dart';
 export 'windows_application_id.dart';

--- a/very_good_core/hooks/lib/src/models/very_good_core_configuration.dart
+++ b/very_good_core/hooks/lib/src/models/very_good_core_configuration.dart
@@ -179,6 +179,7 @@ class VeryGoodCoreConfiguration extends Equatable {
         description,
         windowsApplicationId,
         iOsApplicationId,
+        macOsApplicationId,
         androidNamespace,
         androidApplicationId,
       ];

--- a/very_good_core/hooks/lib/src/models/very_good_core_configuration.dart
+++ b/very_good_core/hooks/lib/src/models/very_good_core_configuration.dart
@@ -140,6 +140,8 @@ class VeryGoodCoreConfiguration extends Equatable {
       organizationName: organizationName,
       iOsApplicationId:
           applicationId != null ? AppleApplicationId(applicationId) : null,
+      macOsApplicationId:
+          applicationId != null ? AppleApplicationId(applicationId) : null,
       windowsApplicationId:
           applicationId != null ? WindowsApplicationId(applicationId) : null,
       androidApplicationId:

--- a/very_good_core/hooks/lib/src/models/very_good_core_configuration.dart
+++ b/very_good_core/hooks/lib/src/models/very_good_core_configuration.dart
@@ -57,7 +57,8 @@ class VeryGoodCoreConfiguration extends Equatable {
     String? organizationName,
     String? description,
     WindowsApplicationId? windowsApplicationId,
-    IosApplicationId? iosApplicationId,
+    AppleApplicationId? iOsApplicationId,
+    AppleApplicationId? macOsApplicationId,
     AndroidApplicationId? androidApplicationId,
     AndroidNamespace? androidNamespace,
   })  : projectName = projectName ?? 'my_app',
@@ -68,8 +69,13 @@ class VeryGoodCoreConfiguration extends Equatable {
           organizationName: this.organizationName,
           projectName: this.projectName,
         );
-    this.iosApplicationId = iosApplicationId ??
-        IosApplicationId.fallback(
+    this.iOsApplicationId = iOsApplicationId ??
+        AppleApplicationId.fallback(
+          organizationName: this.organizationName,
+          projectName: this.projectName,
+        );
+    this.macOsApplicationId = macOsApplicationId ??
+        AppleApplicationId.fallback(
           organizationName: this.organizationName,
           projectName: this.projectName,
         );
@@ -132,8 +138,8 @@ class VeryGoodCoreConfiguration extends Equatable {
     return VeryGoodCoreConfiguration(
       projectName: projectName,
       organizationName: organizationName,
-      iosApplicationId:
-          applicationId != null ? IosApplicationId(applicationId) : null,
+      iOsApplicationId:
+          applicationId != null ? AppleApplicationId(applicationId) : null,
       windowsApplicationId:
           applicationId != null ? WindowsApplicationId(applicationId) : null,
       androidApplicationId:
@@ -154,8 +160,11 @@ class VeryGoodCoreConfiguration extends Equatable {
   /// {@macro windows_application_id}
   late final WindowsApplicationId windowsApplicationId;
 
-  /// {@macro ios_application_id}
-  late final IosApplicationId iosApplicationId;
+  /// {@macro apple_application_id}
+  late final AppleApplicationId iOsApplicationId;
+
+  /// {@macro apple_application_id}
+  late final AppleApplicationId macOsApplicationId;
 
   /// {@macro android_namespace}
   late final AndroidNamespace androidNamespace;
@@ -169,7 +178,7 @@ class VeryGoodCoreConfiguration extends Equatable {
         organizationName,
         description,
         windowsApplicationId,
-        iosApplicationId,
+        iOsApplicationId,
         androidNamespace,
         androidApplicationId,
       ];

--- a/very_good_core/hooks/pre_gen.dart
+++ b/very_good_core/hooks/pre_gen.dart
@@ -38,7 +38,8 @@ void run(HookContext context) {
     'description': configuration.description,
     'android_namespace': configuration.androidNamespace,
     'android_application_id': configuration.androidApplicationId,
-    'ios_application_id': configuration.iosApplicationId,
+    'ios_application_id': configuration.iOsApplicationId,
+    'macos_application_id': configuration.macOsApplicationId,
     'windows_application_id': configuration.windowsApplicationId,
   };
 }

--- a/very_good_core/hooks/test/pre_gen_test.dart
+++ b/very_good_core/hooks/test/pre_gen_test.dart
@@ -38,6 +38,7 @@ void main() {
             'android_namespace': 'app.id',
             'android_application_id': 'app.id',
             'ios_application_id': 'app.id',
+            'macos_application_id': 'app.id',
             'windows_application_id': 'app.id',
           },
         ),

--- a/very_good_core/hooks/test/src/models/apple_application_id_test.dart
+++ b/very_good_core/hooks/test/src/models/apple_application_id_test.dart
@@ -2,18 +2,18 @@ import 'package:test/test.dart';
 import 'package:very_good_core_hooks/very_good_core_hooks.dart';
 
 void main() {
-  group('$IosApplicationId', () {
+  group('$AppleApplicationId', () {
     group('fallback', () {
       test(
         'concatenates organization name with project name in param case',
         () {
           const organizationName = 'com.example.hello-world';
           const projectName = 'my app';
-          final iOsApplicationId = IosApplicationId.fallback(
+          final appleApplicationId = AppleApplicationId.fallback(
             organizationName: organizationName,
             projectName: projectName,
           );
-          expect(iOsApplicationId.value, 'com.example.hello-world.my-app');
+          expect(appleApplicationId.value, 'com.example.hello-world.my-app');
         },
       );
 
@@ -22,11 +22,11 @@ void main() {
         () {
           const organizationName = 'com.example.hello_world';
           const projectName = 'my app';
-          final iOsApplicationId = IosApplicationId.fallback(
+          final appleApplicationId = AppleApplicationId.fallback(
             organizationName: organizationName,
             projectName: projectName,
           );
-          expect(iOsApplicationId.value, 'com.example.hello-world.my-app');
+          expect(appleApplicationId.value, 'com.example.hello-world.my-app');
         },
       );
     });

--- a/very_good_core/hooks/test/src/models/very_good_core_configuration_test.dart
+++ b/very_good_core/hooks/test/src/models/very_good_core_configuration_test.dart
@@ -19,17 +19,22 @@ void main() {
         expect(configuration.description, 'A Very Good App');
       });
 
-      test('windows_application_id to "com.example.my-app"', () {
+      test('windowsApplicationId to "com.example.my-app"', () {
         final configuration = VeryGoodCoreConfiguration();
         expect(configuration.windowsApplicationId.value, 'com.example.my-app');
       });
 
-      test('ios_application_id to "com.example.my-app"', () {
+      test('iOsApplicationId to "com.example.my-app"', () {
         final configuration = VeryGoodCoreConfiguration();
-        expect(configuration.iosApplicationId.value, 'com.example.my-app');
+        expect(configuration.iOsApplicationId.value, 'com.example.my-app');
       });
 
-      test('android_application_id to "com.example.my_app"', () {
+      test('macOsApplicationId to "com.example.my-app"', () {
+        final configuration = VeryGoodCoreConfiguration();
+        expect(configuration.macOsApplicationId.value, 'com.example.my-app');
+      });
+
+      test('androidApplicationId to "com.example.my_app"', () {
         final configuration = VeryGoodCoreConfiguration();
         expect(configuration.androidApplicationId.value, 'com.example.my_app');
       });
@@ -86,7 +91,10 @@ void main() {
               description: 'A Very Good App',
               windowsApplicationId:
                   WindowsApplicationId('com.verygood.very_good_app'),
-              iosApplicationId: IosApplicationId('com.verygood.very_good_app'),
+              iOsApplicationId:
+                  AppleApplicationId('com.verygood.very_good_app'),
+              macOsApplicationId:
+                  AppleApplicationId('com.verygood.very_good_app'),
               androidApplicationId:
                   AndroidApplicationId('com.verygood.very_good_app'),
               androidNamespace: AndroidNamespace('com.verygood.very_good_app'),


### PR DESCRIPTION
## Description

Related to https://github.com/VeryGoodOpenSource/very_good_templates/issues/154. Updating the macOS project so it also uses the application id.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
