### PR TITLE
chore: remove legacy package tag in AndroidManifest.xml

### DIFF
--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#android}}{{project_name.snakeCase()}}_android{{/android}}/android/build.gradle
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#android}}{{project_name.snakeCase()}}_android{{/android}}/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace = "{{org_name.dotCase()}}.example"
+    
     if (project.android.hasProperty("namespace")) {
         namespace '{{org_name.dotCase()}}'
     }

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#android}}{{project_name.snakeCase()}}_android{{/android}}/android/build.gradle
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#android}}{{project_name.snakeCase()}}_android{{/android}}/android/build.gradle
@@ -25,8 +25,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace = "{{org_name.dotCase()}}.example"
-    
     if (project.android.hasProperty("namespace")) {
         namespace '{{org_name.dotCase()}}'
     }

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#android}}{{project_name.snakeCase()}}_android{{/android}}/android/src/main/AndroidManifest.xml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{#android}}{{project_name.snakeCase()}}_android{{/android}}/android/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="{{org_name.dotCase()}}">
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/{{#android}}android{{/android}}/app/build.gradle
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/{{#android}}android{{/android}}/app/build.gradle
@@ -23,6 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
+    namespace = "{{org_name.dotCase()}}.example"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/{{#android}}android{{/android}}/app/src/debug/AndroidManifest.xml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/{{#android}}android{{/android}}/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="{{org_name.dotCase()}}.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/{{#android}}android{{/android}}/app/src/main/AndroidManifest.xml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/{{#android}}android{{/android}}/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="{{org_name.dotCase()}}.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:label="example"
         android:name="${applicationName}"

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/{{#android}}android{{/android}}/app/src/profile/AndroidManifest.xml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/{{project_name.snakeCase()}}/example/{{#android}}android{{/android}}/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="{{org_name.dotCase()}}">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->


### PR DESCRIPTION
## Description

Related to #155

From the [documentation](https://developer.android.com/guide/topics/manifest/manifest-element):
> In the Gradle-based build system, starting with AGP 7.3, don't set the package value in the source manifest file directly. For more information, see [Set the application ID](https://developer.android.com/studio/build/configure-app-module#set-application-id).

Current example AGP version is 7.3

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
