### PR TITLE
fix: set current year var

### DIFF
--- a/very_good_core/__brick__/{{project_name.snakeCase()}}/windows/runner/Runner.rc
+++ b/very_good_core/__brick__/{{project_name.snakeCase()}}/windows/runner/Runner.rc
@@ -93,7 +93,7 @@ BEGIN
             VALUE "FileDescription", "{{project_name.snakeCase()}}" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "{{project_name.snakeCase()}}" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2022 {{windows_application_id}}. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) {{current_year}} {{windows_application_id}}. All rights reserved." "\0"
             VALUE "OriginalFilename", "{{project_name.snakeCase()}}.exe" "\0"
             VALUE "ProductName", "{{project_name.titleCase()}}" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"

--- a/very_good_core/hooks/lib/src/models/very_good_core_configuration.dart
+++ b/very_good_core/hooks/lib/src/models/very_good_core_configuration.dart
@@ -37,7 +37,12 @@ enum _VeryGoodCoreConfigurationVariables {
   ///
   /// Defaults to `A Very Good App`.
   /// {@endtemplate}
-  description._('description');
+  description._('description'),
+
+  /// {@template very_good_core_configuration_variables.current_year}
+  /// Defaults to the current year.
+  /// {@endtemplate}
+  currentYear._('current_year');
 
   const _VeryGoodCoreConfigurationVariables._(this.key);
 
@@ -135,6 +140,16 @@ class VeryGoodCoreConfiguration extends Equatable {
       );
     }
 
+    final currentYear =
+        vars[_VeryGoodCoreConfigurationVariables.currentYear.key];
+    if (currentYear is! int?) {
+      throw ArgumentError.value(
+        vars,
+        'vars',
+        '''Expected a value for key "${_VeryGoodCoreConfigurationVariables.currentYear.key}" to be of type int?, got $currentYear.''',
+      );
+    }
+
     return VeryGoodCoreConfiguration(
       projectName: projectName,
       organizationName: organizationName,
@@ -162,6 +177,9 @@ class VeryGoodCoreConfiguration extends Equatable {
 
   /// {@macro very_good_core_configuration_variables.description}
   final String description;
+
+  /// {@macro very_good_core_configuration_variables.current_year}
+  final int currentYear = DateTime.now().year;
 
   /// {@macro windows_application_id}
   late final WindowsApplicationId windowsApplicationId;

--- a/very_good_core/hooks/lib/src/models/very_good_core_configuration.dart
+++ b/very_good_core/hooks/lib/src/models/very_good_core_configuration.dart
@@ -61,6 +61,7 @@ class VeryGoodCoreConfiguration extends Equatable {
     String? projectName,
     String? organizationName,
     String? description,
+    int? currentYear,
     WindowsApplicationId? windowsApplicationId,
     AppleApplicationId? iOsApplicationId,
     AppleApplicationId? macOsApplicationId,

--- a/very_good_core/hooks/pre_gen.dart
+++ b/very_good_core/hooks/pre_gen.dart
@@ -41,5 +41,6 @@ void run(HookContext context) {
     'ios_application_id': configuration.iOsApplicationId,
     'macos_application_id': configuration.macOsApplicationId,
     'windows_application_id': configuration.windowsApplicationId,
+    'current_year': configuration.currentYear,
   };
 }

--- a/very_good_core/hooks/test/src/models/very_good_core_configuration_test.dart
+++ b/very_good_core/hooks/test/src/models/very_good_core_configuration_test.dart
@@ -38,6 +38,11 @@ void main() {
         final configuration = VeryGoodCoreConfiguration();
         expect(configuration.androidApplicationId.value, 'com.example.my_app');
       });
+
+      test('currentYear to the current year', () {
+        final configuration = VeryGoodCoreConfiguration();
+        expect(configuration.currentYear, DateTime.now().year);
+      });
     });
 
     group('throws', () {
@@ -79,6 +84,7 @@ void main() {
           'org_name': 'com.verygood',
           'application_id': 'com.verygood.very_good_app',
           'description': 'A Very Good App',
+          'current_year': 2024,
         };
 
         final configuration = VeryGoodCoreConfiguration.fromHookVars(vars);
@@ -109,6 +115,7 @@ void main() {
           'org_name': 'com.verygood',
           'application_id': '',
           'description': 'A Very Good App',
+          'current_year': 2024,
         };
 
         final configuration = VeryGoodCoreConfiguration.fromHookVars(vars);
@@ -119,6 +126,7 @@ void main() {
               projectName: 'very good app',
               organizationName: 'com.verygood',
               description: 'A Very Good App',
+              currentYear: 2024,
               windowsApplicationId:
                   WindowsApplicationId('com.verygood.very-good-app'),
               iOsApplicationId:
@@ -189,6 +197,21 @@ void main() {
                 (error) => error.message,
                 'message',
                 '''Expected a value for key "description" to be of type String?, got 42.''',
+              ),
+            ),
+          );
+        });
+
+        test('when "current_year" is not an int?', () {
+          final vars = <String, dynamic>{'current_year': 'string_value'};
+
+          expect(
+            () => VeryGoodCoreConfiguration.fromHookVars(vars),
+            throwsA(
+              isA<ArgumentError>().having(
+                (error) => error.message,
+                'message',
+                '''Expected a value for key "current_year" to be of type int?, got string_value.''',
               ),
             ),
           );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Resolves #162 

This PR introduces a dynamic current_year variable to the project templates, allowing the copyright year to be automatically updated based on the current year. This change ensures that the copyright message is always accurate and up-to-date without requiring manual updates each year.

<!--- Describe your changes in detail -->
## Changes
- Added current_year variable to automatically reflect the current year.
- Updated copyright messages to use the current_year variable instead of a static year.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
