### PR TITLE
chore: update copyright year in Windows Runner.rc

### DIFF
--- a/very_good_core/__brick__/{{project_name.snakeCase()}}/windows/runner/Runner.rc
+++ b/very_good_core/__brick__/{{project_name.snakeCase()}}/windows/runner/Runner.rc
@@ -93,7 +93,7 @@ BEGIN
             VALUE "FileDescription", "{{project_name.snakeCase()}}" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "{{project_name.snakeCase()}}" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2022 {{windows_application_id}}. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) {{current_year}} {{windows_application_id}}. All rights reserved." "\0"
             VALUE "OriginalFilename", "{{project_name.snakeCase()}}.exe" "\0"
             VALUE "ProductName", "{{project_name.titleCase()}}" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"

--- a/very_good_core/hooks/lib/src/models/very_good_core_configuration.dart
+++ b/very_good_core/hooks/lib/src/models/very_good_core_configuration.dart
@@ -163,6 +163,9 @@ class VeryGoodCoreConfiguration extends Equatable {
   /// {@macro very_good_core_configuration_variables.description}
   final String description;
 
+  /// {@macro very_good_core_configuration_variables.current_year}
+  final int currentYear = DateTime.now().year;
+
   /// {@macro windows_application_id}
   late final WindowsApplicationId windowsApplicationId;
 

--- a/very_good_core/hooks/pre_gen.dart
+++ b/very_good_core/hooks/pre_gen.dart
@@ -41,5 +41,6 @@ void run(HookContext context) {
     'ios_application_id': configuration.iOsApplicationId,
     'macos_application_id': configuration.macOsApplicationId,
     'windows_application_id': configuration.windowsApplicationId,
+    'current_year': configuration.currentYear,
   };
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
This PR introduces a dynamic current_year variable to the project templates, allowing the copyright year to be automatically updated based on the current year. This change ensures that the copyright message is always accurate and up-to-date without requiring manual updates each year.

## Changes
- Added current_year variable to automatically reflect the current year.
- Updated copyright messages to use the current_year variable instead of a static year.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
