### PR TITLE
chore: update to Flutter 3.27 and Dart 3.6

### DIFF
--- a/.github/workflows/very_good_core.yaml
+++ b/.github/workflows/very_good_core.yaml
@@ -31,7 +31,7 @@ jobs:
         flutter-version:
           # The version of Flutter to use should use the minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.24.0"
+          - "3.27.0"
           - "3.x"
 
     steps:

--- a/.github/workflows/very_good_dart_cli.yaml
+++ b/.github/workflows/very_good_dart_cli.yaml
@@ -27,7 +27,7 @@ jobs:
         dart-version:
           # The minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.5.0"
+          - "3.6.0"
           - "stable"
 
     steps:

--- a/.github/workflows/very_good_dart_package.yaml
+++ b/.github/workflows/very_good_dart_package.yaml
@@ -27,7 +27,7 @@ jobs:
         dart-version:
           # The minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.5.0"
+          - "3.6.0"
           - "stable"
 
     steps:

--- a/.github/workflows/very_good_flame_game.yaml
+++ b/.github/workflows/very_good_flame_game.yaml
@@ -31,7 +31,7 @@ jobs:
         flutter-version:
           # The version of Flutter to use should use the minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.24.0"
+          - "3.27.0"
           - "3.x"
 
     steps:

--- a/.github/workflows/very_good_flutter_package.yaml
+++ b/.github/workflows/very_good_flutter_package.yaml
@@ -27,7 +27,7 @@ jobs:
         flutter-version:
           # The version of Flutter to use should use the minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.24.0"
+          - "3.27.0"
           - "3.x"
 
     steps:

--- a/.github/workflows/very_good_flutter_plugin.yaml
+++ b/.github/workflows/very_good_flutter_plugin.yaml
@@ -27,7 +27,7 @@ jobs:
         flutter-version:
           # The version of Flutter to use should use the minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.24.0"
+          - "3.27.0"
           - "3.x"
 
         platform:

--- a/.github/workflows/very_good_wear_app.yaml
+++ b/.github/workflows/very_good_wear_app.yaml
@@ -27,7 +27,7 @@ jobs:
         flutter-version:
           # The version of Flutter to use should use the minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.24.0"
+          - "3.27.0"
           - "3.x"
 
     steps:

--- a/tool/dependency_tightener/pubspec.yaml
+++ b/tool/dependency_tightener/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
 
 dependencies:
   args: ^2.5.0

--- a/very_good_core/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_core/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
 
 dependencies:
   bloc: ^8.1.4

--- a/very_good_core/hooks/pubspec.yaml
+++ b/very_good_core/hooks/pubspec.yaml
@@ -1,7 +1,7 @@
 name: very_good_core_hooks
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
 
 dependencies:
   clock: ^1.1.1

--- a/very_good_dart_cli/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_dart_cli/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
 
 dependencies:
   args: ^2.6.0

--- a/very_good_dart_cli/hooks/pubspec.yaml
+++ b/very_good_dart_cli/hooks/pubspec.yaml
@@ -1,7 +1,7 @@
 name: very_good_dart_cli_hooks
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
 
 dependencies:
   mason: ^0.1.0

--- a/very_good_dart_package/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_dart_package/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0+1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
 
 dev_dependencies:
   mocktail: ^1.0.4

--- a/very_good_flame_game/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_flame_game/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
 
 dependencies:
   audioplayers: ^6.1.0

--- a/very_good_flame_game/hooks/pubspec.yaml
+++ b/very_good_flame_game/hooks/pubspec.yaml
@@ -1,7 +1,7 @@
 name: very_good_flame_game_hooks
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
 
 dependencies:
   clock: ^1.1.1

--- a/very_good_flutter_package/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_flutter_package/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0+1
 {{^publishable}}publish_to: none{{/publishable}}
 
 environment:
-  sdk: ^3.5.0
-  flutter: ^3.24.0
+  sdk: ^3.6.0
+  flutter: ^3.27.0
 
 dependencies:
   flutter:

--- a/very_good_flutter_plugin/hooks/lib/version.dart
+++ b/very_good_flutter_plugin/hooks/lib/version.dart
@@ -8,7 +8,7 @@ library;
 const $templateVersion = '0.9.0';
 
 /// The Flutter version associated with the template version.
-const $flutterVersion = '3.24.0';
+const $flutterVersion = '3.27.0';
 
 /// The minimum Dart version required by the template.
 ///
@@ -18,4 +18,4 @@ const $flutterVersion = '3.24.0';
 /// See also:
 ///
 /// * [Flutter SDK archive](https://docs.flutter.dev/release/archive)
-const $minDartVersion = '3.5.0';
+const $minDartVersion = '3.6.0';

--- a/very_good_flutter_plugin/hooks/pubspec.yaml
+++ b/very_good_flutter_plugin/hooks/pubspec.yaml
@@ -1,7 +1,7 @@
 name: very_good_flutter_plugin_hooks
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
 
 dependencies:
   mason: ^0.1.0

--- a/very_good_wear_app/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_wear_app/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
 
 dependencies:
   bloc: ^8.1.4

--- a/very_good_wear_app/hooks/pubspec.yaml
+++ b/very_good_wear_app/hooks/pubspec.yaml
@@ -1,7 +1,7 @@
 name: very_good_wear_app_hooks
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0
 
 dependencies:
   mason: ^0.1.0


### PR DESCRIPTION
## Description

Closes #222. Moves templates to newest version of Flutter & Dart. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 🧪 Test
