### PR TITLE
fix(android): correct source sets to ensure plugin compatibility

### DIFF
--- a/very_good_core/__brick__/{{project_name.snakeCase()}}/android/app/build.gradle.kts
+++ b/very_good_core/__brick__/{{project_name.snakeCase()}}/android/app/build.gradle.kts
@@ -27,10 +27,6 @@ android {
         jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
-    sourceSets.getByName("main") {
-        java.setSrcDirs(listOf("src/main/kotlin"))
-    }
-
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "{{android_application_id}}"


### PR DESCRIPTION
## Description

This pull request removes the explicit sourceSets configuration from the `android/app/build.gradle.kts` file in the Very Good Core template.

Previously, the configuration included the following block:

```
sourceSets.getByName("main") {
    java.setSrcDirs(listOf("src/main/kotlin"))
}
```

This code overrides the default source directories for the Android build system, restricting it to look **only** in `src/main/kotlin`. As a result, it ignores `src/main/java`, which is where the `GeneratedPluginRegistrant.java` file is located — a file that’s essential for registering Flutter plugins.

By removing this block, we allow the Android build system to consider both `src/main/java` and `src/main/kotlin`, ensuring proper plugin registration.

This change also aligns the template with the [official Flutter SDK app template](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/templates/app/android-kotlin.tmpl/app/build.gradle.kts.tmpl).

Related issue: #291 

Thanks @yuruyuri16 for suggesting this improvement!

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
