### PR TITLE
chore: upgrade very_good_analysis to 10.1.0

### DIFF
--- a/tool/dependency_tightener/pubspec.yaml
+++ b/tool/dependency_tightener/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   mocktail: ^1.0.4
   test: ^1.25.7
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0
 
 executables:
   dependency_tightener:

--- a/very_good_core/__brick__/pubspec.yaml
+++ b/very_good_core/__brick__/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0
 
 flutter:
   generate: true

--- a/very_good_core/hooks/pubspec.yaml
+++ b/very_good_core/hooks/pubspec.yaml
@@ -11,4 +11,4 @@ dependencies:
 dev_dependencies:
   mocktail: ^1.0.3
   test: ">=1.25.2 <1.27.0"
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_dart_cli/__brick__/pubspec.yaml
+++ b/very_good_dart_cli/__brick__/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
   build_version: ^2.1.3
   mocktail: ^1.0.4
   test: ^1.27.0
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0
 
 executables:
   {{executable_name.snakeCase()}}:

--- a/very_good_dart_cli/hooks/pubspec.yaml
+++ b/very_good_dart_cli/hooks/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
 dev_dependencies:
   mocktail: ^1.0.3
   test: ">=1.25.2 <1.27.0"
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_dart_package/__brick__/pubspec.yaml
+++ b/very_good_dart_package/__brick__/pubspec.yaml
@@ -9,4 +9,4 @@ environment:
 dev_dependencies:
   mocktail: ^1.0.4
   test: ^1.27.0
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flame_game/__brick__/pubspec.yaml
+++ b/very_good_flame_game/__brick__/pubspec.yaml
@@ -31,7 +31,7 @@ dev_dependencies:
     sdk: flutter
   mockingjay: ^2.0.0
   mocktail: ^1.0.4
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0
 
 flutter:
   generate: true

--- a/very_good_flame_game/hooks/pubspec.yaml
+++ b/very_good_flame_game/hooks/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   mocktail: ^1.0.3
   test: ">=1.25.2 <1.27.0"
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flutter_package/__brick__/pubspec.yaml
+++ b/very_good_flutter_package/__brick__/pubspec.yaml
@@ -15,4 +15,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flutter_plugin/__brick__/{{#android}}{{project_name.snakeCase()}}_android{{/android}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{#android}}{{project_name.snakeCase()}}_android{{/android}}/pubspec.yaml
@@ -25,4 +25,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flutter_plugin/__brick__/{{#ios}}{{project_name.snakeCase()}}_ios{{/ios}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{#ios}}{{project_name.snakeCase()}}_ios{{/ios}}/pubspec.yaml
@@ -24,4 +24,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flutter_plugin/__brick__/{{#linux}}{{project_name.snakeCase()}}_linux{{/linux}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{#linux}}{{project_name.snakeCase()}}_linux{{/linux}}/pubspec.yaml
@@ -23,4 +23,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flutter_plugin/__brick__/{{#macos}}{{project_name.snakeCase()}}_macos{{/macos}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{#macos}}{{project_name.snakeCase()}}_macos{{/macos}}/pubspec.yaml
@@ -23,4 +23,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flutter_plugin/__brick__/{{#web}}{{project_name.snakeCase()}}_web{{/web}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{#web}}{{project_name.snakeCase()}}_web{{/web}}/pubspec.yaml
@@ -25,4 +25,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flutter_plugin/__brick__/{{#windows}}{{project_name.snakeCase()}}_windows{{/windows}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{#windows}}{{project_name.snakeCase()}}_windows{{/windows}}/pubspec.yaml
@@ -23,4 +23,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/example/actions/check_platform_name/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/example/actions/check_platform_name/pubspec.yaml
@@ -14,4 +14,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/example/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/example/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0
 
 flutter:
   uses-material-design: true

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}/pubspec.yaml
@@ -18,4 +18,4 @@ dev_dependencies:
     sdk: flutter
   mocktail: ^1.0.4
   plugin_platform_interface: ^2.1.8
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}_platform_interface/pubspec.yaml
+++ b/very_good_flutter_plugin/__brick__/{{project_name.snakeCase()}}_platform_interface/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flutter_plugin/hooks/pubspec.yaml
+++ b/very_good_flutter_plugin/hooks/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
 dev_dependencies:
   mocktail: ^1.0.3
   test: ">=1.25.2 <1.27.0"
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_flutter_plugin/tool/merge_coverage/pubspec.yaml
+++ b/very_good_flutter_plugin/tool/merge_coverage/pubspec.yaml
@@ -9,4 +9,4 @@ dependencies:
   path: ^1.8.3
 
 dev_dependencies:
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0

--- a/very_good_wear_app/__brick__/pubspec.yaml
+++ b/very_good_wear_app/__brick__/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0
 
 flutter:
   generate: true

--- a/very_good_wear_app/hooks/pubspec.yaml
+++ b/very_good_wear_app/hooks/pubspec.yaml
@@ -9,4 +9,4 @@ dependencies:
 dev_dependencies:
   mocktail: ^1.0.3
   test: ">=1.25.2 <1.27.0"
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.1.0


### PR DESCRIPTION
## Description

Upgrades `very_good_analysis` from `^10.0.0` to `^10.1.0` across all templates and hooks.

Closes #395

## Changes

- Updated `very_good_analysis` dependency to `^10.1.0` in all 23 pubspec.yaml files across:
  - Template bricks (very_good_core, very_good_dart_cli, very_good_dart_package, very_good_flame_game, very_good_flutter_package, very_good_flutter_plugin, very_good_wear_app)
  - Hook packages
  - Tool packages

## Status

⚠️ **Draft PR** - The stable version 10.1.0 is not yet released on pub.dev (only 10.1.0-rc.2 is available).

This PR will be ready for review once:
- [ ] `very_good_analysis` 10.1.0 stable is published on pub.dev
- [ ] All CI/CD checks pass
- [ ] Test coverage is maintained

## Requirements

As specified in the issue:
- [ ] All CI/CD checks are passing
- [ ] There is no drop in the test coverage percentage