### PR TITLE
fix: add missing LICENSE file to very_good_core brick

### DIFF
--- a/very_good_core/__brick__/LICENSE
+++ b/very_good_core/__brick__/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) {{current_year}} {{org_name}}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Description

In the [Output](https://github.com/VeryGoodOpenSource/very_good_templates/tree/main/very_good_core#output-) section of the `very_good_core` documentation the `LICENSE` file is referenced, but it's actually missing from the `__brick__` folder.

This PR adds it (MIT), using `current_year` and `org_name`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
