### PR TITLE
docs(very_good_core): fix and simplify translation docs

### DIFF
--- a/.github/.cspell/words_dictionary.txt
+++ b/.github/.cspell/words_dictionary.txt
@@ -30,3 +30,6 @@ verygood # Very Good, but without a space.
 xcode # Apple's integrated development environment.
 xcworkspace # Abbreviation for Xcode workspace.
 xcassets # Abbreviation for Xcode assets.
+hola # part of translations example
+mundo # part of translations example
+saludo # part of translations example

--- a/very_good_core/__brick__/.github/cspell.json
+++ b/very_good_core/__brick__/.github/cspell.json
@@ -20,6 +20,9 @@
     "localizable",
     "mostrado",
     "página",
-    "Texto"
+    "Texto",
+    "Hola",
+    "Mundo",
+    "Saludo"
   ]
 }

--- a/very_good_core/__brick__/README.md
+++ b/very_good_core/__brick__/README.md
@@ -77,19 +77,7 @@ This project follows the [official internationalization guide for Flutter][inter
 
 ### Adding Strings
 
-1. To add a new localizable string, open the `app_en.arb` file at `lib/l10n/arb/app_en.arb`.
-
-```arb
-{
-    "@@locale": "en",
-    "counterAppBarTitle": "Counter",
-    "@counterAppBarTitle": {
-        "description": "Text shown in the AppBar of the Counter Page"
-    }
-}
-```
-
-2. Then add a new key/value and description
+1. To add a new localizable string, open the `app_en.arb` file at `lib/l10n/arb/app_en.arb` and add a new key/value pair with the relevant description (optional):
 
 ```arb
 {
@@ -100,12 +88,12 @@ This project follows the [official internationalization guide for Flutter][inter
     },
     "helloWorld": "Hello World",
     "@helloWorld": {
-        "description": "Hello World Text"
+        "description": "Hello World greeting."
     }
 }
 ```
 
-3. Use the new string
+1. Use the new string:
 
 ```dart
 import 'package:{{project_name.snakeCase()}}/l10n/l10n.dart';
@@ -135,7 +123,7 @@ Update the `CFBundleLocalizations` array in the `Info.plist` at `ios/Runner/Info
 
 ### Adding Translations
 
-1. For each supported locale, add a new ARB file in `lib/l10n/arb`.
+1. For each supported locale, add a new ARB file in `lib/l10n/arb`:
 
 ```
 ├── l10n
@@ -144,19 +132,7 @@ Update the `CFBundleLocalizations` array in the `Info.plist` at `ios/Runner/Info
 │   │   └── app_es.arb
 ```
 
-2. Add the translated strings to each `.arb` file:
-
-`app_en.arb`
-
-```arb
-{
-    "@@locale": "en",
-    "counterAppBarTitle": "Counter",
-    "@counterAppBarTitle": {
-        "description": "Text shown in the AppBar of the Counter Page"
-    }
-}
-```
+1. Add the translated strings to the new `.arb` file:
 
 `app_es.arb`
 
@@ -166,15 +142,17 @@ Update the `CFBundleLocalizations` array in the `Info.plist` at `ios/Runner/Info
     "counterAppBarTitle": "Contador",
     "@counterAppBarTitle": {
         "description": "Texto mostrado en la AppBar de la página del contador"
-    }
+    },
+    "helloWorld": "Hola Mundo",
+    "@helloWorld": {
+        "description": "Saludo Hola Mundo."
+    }    
 }
 ```
 
 ### Generating Translations
 
 To use the latest translations changes, you will need to generate them:
-
-1. Generate localizations for the current project:
 
 ```sh
 flutter gen-l10n --arb-dir="lib/l10n/arb"


### PR DESCRIPTION
## Description

This PR is broken down in 3 commits, so they're easy to either pick or discard individually.

 - Fix link to official internationalization docs, this is a straight fix that should be a no brainer to merge.
 - Replace the link to the localization API docs with a link to the official ARB documentation. IMHO the link to the API reference for localization is not very helpful, but I've found myself several times looking for the official ARB docs in order to check format specifics.
 - Simplifies the translation documentation in the `README`. I feel that the current translation docs take a very big chunk of the `README`, so this last commit simplifies them while hopefully keeping them as useful. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation
