### PR TITLE
fix(very_good_app_ui): resolve LICENSE template variables

### DIFF
--- a/very_good_app_ui/.gitignore
+++ b/very_good_app_ui/.gitignore
@@ -13,5 +13,5 @@ pubspec.lock
 mason-lock.json
 output/
 
-# Files and directories created by MacOS
-.DS_Store
+# Conventional directory for build outputs
+build/

--- a/very_good_app_ui/__brick__/LICENSE
+++ b/very_good_app_ui/__brick__/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) {{current_year}} {{org_name}}
+Copyright (c) {{current_year}} {{project_name.pascalCase()}}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/very_good_app_ui/hooks/analysis_options.yaml
+++ b/very_good_app_ui/hooks/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.yaml

--- a/very_good_app_ui/hooks/lib/src/very_good_core_configuration.dart
+++ b/very_good_app_ui/hooks/lib/src/very_good_core_configuration.dart
@@ -1,0 +1,86 @@
+import 'package:equatable/equatable.dart';
+
+/// The variables specified by this hook.
+///
+/// The variables can be found in the Brick's `brick.yaml` file. They are
+/// initially included in the `HookContext.vars` map.
+///
+/// See also:
+///
+/// * [brick.yaml documentation](https://docs.brickhub.dev/brick-structure#brickyaml)
+enum _VeryGoodCoreConfigurationVariables {
+  /// {@template very_good_core_configuration_variables.project_name}
+  /// The project name.
+  ///
+  /// Defaults to `my_app`.
+  /// {@endtemplate}
+  projectName._('project_name'),
+
+  /// {@template very_good_core_configuration_variables.description}
+  /// A short project description.
+  ///
+  /// Defaults to `A Very Good App`.
+  /// {@endtemplate}
+  description._('description')
+  ;
+
+  const _VeryGoodCoreConfigurationVariables._(this.key);
+
+  /// The key used in the `HookContext.vars` [Map].
+  ///
+  /// This should match the variable key in the `brick.yaml`.
+  final String key;
+}
+
+/// {@template very_good_core_configuration}
+/// Configuration for the `very_good_core` brick.
+/// {@endtemplate}
+class VeryGoodCoreConfiguration extends Equatable {
+  /// {@macro very_good_core_configuration}
+  const VeryGoodCoreConfiguration({
+    String? projectName,
+    String? description,
+  }) : projectName = projectName ?? 'my_app',
+       description = description ?? 'A Very Good App';
+
+  /// Deserializes a [VeryGoodCoreConfiguration] from a `Map<String, dynamic>`
+  /// used to represent the configuration in the `HookContext.vars` map.
+  factory VeryGoodCoreConfiguration.fromHookVars(Map<String, dynamic> vars) {
+    final projectName =
+        vars[_VeryGoodCoreConfigurationVariables.projectName.key];
+    if (projectName is! String?) {
+      throw ArgumentError.value(
+        vars,
+        'vars',
+        '''Expected a value for key "${_VeryGoodCoreConfigurationVariables.projectName.key}" to be of type String?, got $projectName.''',
+      );
+    }
+
+    final description =
+        vars[_VeryGoodCoreConfigurationVariables.description.key];
+    if (description is! String?) {
+      throw ArgumentError.value(
+        vars,
+        'vars',
+        '''Expected a value for key "${_VeryGoodCoreConfigurationVariables.description.key}" to be of type String?, got $description.''',
+      );
+    }
+
+    return VeryGoodCoreConfiguration(
+      projectName: projectName,
+      description: description,
+    );
+  }
+
+  /// {@macro very_good_core_configuration_variables.project_name}
+  final String projectName;
+
+  /// {@macro very_good_core_configuration_variables.description}
+  final String description;
+
+  @override
+  List<Object?> get props => [
+    projectName,
+    description,
+  ];
+}

--- a/very_good_app_ui/hooks/lib/very_good_core_hooks.dart
+++ b/very_good_app_ui/hooks/lib/very_good_core_hooks.dart
@@ -1,0 +1,1 @@
+export 'src/very_good_core_configuration.dart';

--- a/very_good_app_ui/hooks/pre_gen.dart
+++ b/very_good_app_ui/hooks/pre_gen.dart
@@ -1,0 +1,41 @@
+import 'package:clock/clock.dart';
+import 'package:mason/mason.dart';
+import 'package:very_good_core_hooks/very_good_core_hooks.dart';
+
+void run(HookContext context) {
+  final configuration = VeryGoodCoreConfiguration.fromHookVars(context.vars);
+
+  context.vars = {
+    /// Below are all the variables that are accessible in the templates.
+    ///
+    /// You can access them using the Mustache syntax within the template files
+    /// (those under `__brick__`). For example:
+    ///
+    /// ```dart
+    /// // __brick__/pubspec.yaml
+    /// name: {{project_name}}
+    /// ```
+    ///
+    /// This will be replaced with the value of the `project_name` variable.
+    ///
+    /// By design, Mustache is a  "logic-less" template language, meaning it
+    /// does not have the ability to construct logical expressions. From the
+    /// documentation:
+    ///
+    /// > We call it "logic-less" because there are no if statements, else
+    /// > clauses, or for loops. Instead there are only tags.
+    ///
+    /// This means that you can't use Mustache to add logical expressions to
+    /// your templates. If you need to add logical expressions, you should
+    /// evaluate the expression within this pre-generation hook (`pre_gen.dart`)
+    /// and pass the result as a variable to the template.
+    ///
+    /// See also:
+    ///
+    /// * [Mustache documentation](https://mustache.github.io/mustache.5.html)
+    /// * [Mason conditional documentation](https://docs.brickhub.dev/brick-syntax#-conditionals)
+    'project_name': configuration.projectName,
+    'description': configuration.description,
+    'current_year': clock.now().year.toString(),
+  };
+}

--- a/very_good_app_ui/hooks/pubspec.yaml
+++ b/very_good_app_ui/hooks/pubspec.yaml
@@ -1,0 +1,14 @@
+name: very_good_core_hooks
+
+environment:
+  sdk: ^3.11.0
+
+dependencies:
+  clock: ^1.1.1
+  equatable: ^2.0.5
+  mason: ^0.1.0
+
+dev_dependencies:
+  mocktail: ^1.0.3
+  test: ">=1.25.2 <1.27.0"
+  very_good_analysis: ^10.2.0

--- a/very_good_app_ui/hooks/test/pre_gen_test.dart
+++ b/very_good_app_ui/hooks/test/pre_gen_test.dart
@@ -1,0 +1,43 @@
+import 'package:clock/clock.dart';
+import 'package:mason/mason.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../pre_gen.dart' as pre_gen;
+
+class _MockHookContext extends Mock implements HookContext {}
+
+void main() {
+  group('pre_gen', () {
+    late HookContext context;
+
+    setUp(() {
+      context = _MockHookContext();
+    });
+
+    test('populates variables', () {
+      withClock(Clock.fixed(DateTime(2020)), () {
+        final vars = {
+          'project_name': 'my_app',
+          'description': 'A new Flutter project.',
+        };
+        when(() => context.vars).thenReturn(vars);
+
+        pre_gen.run(context);
+
+        final newVars =
+            verify(() => context.vars = captureAny()).captured.last
+                as Map<String, dynamic>;
+
+        expect(
+          newVars,
+          equals({
+            'project_name': 'my_app',
+            'description': 'A new Flutter project.',
+            'current_year': '2020',
+          }),
+        );
+      });
+    });
+  });
+}

--- a/very_good_app_ui/hooks/test/src/very_good_core_configuration_test.dart
+++ b/very_good_app_ui/hooks/test/src/very_good_core_configuration_test.dart
@@ -1,0 +1,88 @@
+import 'package:test/test.dart';
+import 'package:very_good_core_hooks/very_good_core_hooks.dart';
+
+void main() {
+  group('$VeryGoodCoreConfiguration', () {
+    group('defaults', () {
+      test('project_name to "my_app"', () {
+        const configuration = VeryGoodCoreConfiguration();
+        expect(configuration.projectName, 'my_app');
+      });
+
+      test('description to "A Very Good App"', () {
+        const configuration = VeryGoodCoreConfiguration();
+        expect(configuration.description, 'A Very Good App');
+      });
+    });
+
+    group('fromHookVars', () {
+      test('decodes as expected', () {
+        final vars = {
+          'project_name': 'very good app',
+          'description': 'A Very Good App',
+        };
+
+        final configuration = VeryGoodCoreConfiguration.fromHookVars(vars);
+        expect(
+          configuration,
+          equals(
+            const VeryGoodCoreConfiguration(
+              projectName: 'very good app',
+              description: 'A Very Good App',
+            ),
+          ),
+        );
+      });
+
+      test('defaults id when empty', () {
+        final vars = {
+          'project_name': 'very good app',
+          'description': 'A Very Good App',
+        };
+
+        final configuration = VeryGoodCoreConfiguration.fromHookVars(vars);
+        expect(
+          configuration,
+          equals(
+            const VeryGoodCoreConfiguration(
+              projectName: 'very good app',
+              description: 'A Very Good App',
+            ),
+          ),
+        );
+      });
+
+      group('throws $ArgumentError', () {
+        test('when "project_name" is not a String?', () {
+          final vars = <String, dynamic>{'project_name': 42};
+
+          expect(
+            () => VeryGoodCoreConfiguration.fromHookVars(vars),
+            throwsA(
+              isA<ArgumentError>().having(
+                (error) => error.message,
+                'message',
+                '''Expected a value for key "project_name" to be of type String?, got 42.''',
+              ),
+            ),
+          );
+        });
+
+        test('when "description" is not a String?', () {
+          final vars = <String, dynamic>{'description': 42};
+
+          expect(
+            () => VeryGoodCoreConfiguration.fromHookVars(vars),
+            throwsA(
+              isA<ArgumentError>().having(
+                (error) => error.message,
+                'message',
+                '''Expected a value for key "description" to be of type String?, got 42.''',
+              ),
+            ),
+          );
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

* Add pre-generation hooks to populate `current_year`, which was previously never set in the LICENSE template.

* Replace `org_name` with `project_name` in the LICENSE copyright holder since this is a UI package, not an app template.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
