### PR TITLE
feat(very_good_app_ui): add responsive typography system

### DIFF
--- a/very_good_app_ui/__brick__/lib/src/extensions/build_context_extensions.dart
+++ b/very_good_app_ui/__brick__/lib/src/extensions/build_context_extensions.dart
@@ -7,4 +7,7 @@ extension AppThemeBuildContext on BuildContext {
 
   /// Returns the [AppSpacing] from the current theme.
   AppSpacing get appSpacing => Theme.of(this).extension<AppSpacing>()!;
+
+  /// Returns the [AppTextStyles] from the current theme.
+  AppTextStyles get appTextStyles => Theme.of(this).extension<AppTextStyles>()!;
 }

--- a/very_good_app_ui/__brick__/lib/src/theme/app_text_styles.dart
+++ b/very_good_app_ui/__brick__/lib/src/theme/app_text_styles.dart
@@ -1,0 +1,308 @@
+import 'package:{{project_name.snakeCase()}}/{{project_name.snakeCase()}}.dart';
+
+/// {@template app_text_styles}
+/// Typography system template. Subject to change based on project Figma specs.
+/// Provides both desktop and mobile text styles.
+/// {@endtemplate}
+class AppTextStyles extends ThemeExtension<AppTextStyles> {
+  /// {@macro app_text_styles}
+  const AppTextStyles();
+
+  /// ============ DESKTOP TEXT STYLES ============
+
+  /// Display Large - Desktop: 48px, Bold, lineHeight: 56, letterSpacing: -2
+  static const TextStyle displayLargeDesktop = TextStyle(
+    fontSize: 48,
+    fontWeight: FontWeight.w700,
+    height: 56 / 48,
+    letterSpacing: -2,
+  );
+
+  /// Display Medium - Desktop: 40px, Bold, lineHeight: 48, letterSpacing: -1.5
+  static const TextStyle displayMediumDesktop = TextStyle(
+    fontSize: 40,
+    fontWeight: FontWeight.w700,
+    height: 48 / 40,
+    letterSpacing: -1.5,
+  );
+
+  /// Display Small - Desktop: 36px, Bold, lineHeight: 44, letterSpacing: -1.5
+  static const TextStyle displaySmallDesktop = TextStyle(
+    fontSize: 36,
+    fontWeight: FontWeight.w700,
+    height: 44 / 36,
+    letterSpacing: -1.5,
+  );
+
+  /// Headline Large - Desktop: 32px, SemiBold, lineHeight: 40, spacing: -1.5
+  static const TextStyle headlineLargeDesktop = TextStyle(
+    fontSize: 32,
+    fontWeight: FontWeight.w600,
+    height: 40 / 32,
+    letterSpacing: -1.5,
+  );
+
+  /// Headline Medium - Desktop: 24px, SemiBold, lineHeight: 32, spacing: -1
+  static const TextStyle headlineMediumDesktop = TextStyle(
+    fontSize: 24,
+    fontWeight: FontWeight.w600,
+    height: 32 / 24,
+    letterSpacing: -1,
+  );
+
+  /// Headline Small - Desktop: 20px, SemiBold, lineHeight: 28, spacing: -0.75
+  static const TextStyle headlineSmallDesktop = TextStyle(
+    fontSize: 20,
+    fontWeight: FontWeight.w600,
+    height: 28 / 20,
+    letterSpacing: -0.75,
+  );
+
+  /// Title Large - Desktop: 24px, Medium, lineHeight: 32, letterSpacing: -0.5
+  static const TextStyle titleLargeDesktop = TextStyle(
+    fontSize: 24,
+    fontWeight: FontWeight.w500,
+    height: 32 / 24,
+    letterSpacing: -0.5,
+  );
+
+  /// Title Medium - Desktop: 20px, Medium, lineHeight: 28, letterSpacing: -0.5
+  static const TextStyle titleMediumDesktop = TextStyle(
+    fontSize: 20,
+    fontWeight: FontWeight.w500,
+    height: 28 / 20,
+    letterSpacing: -0.5,
+  );
+
+  /// Title Small - Desktop: 16px, Medium, lineHeight: 24, letterSpacing: -0.25
+  static const TextStyle titleSmallDesktop = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w500,
+    height: 24 / 16,
+    letterSpacing: -0.25,
+  );
+
+  /// Label Large - Desktop: 16px, Medium, lineHeight: 20, letterSpacing: -0.15
+  static const TextStyle labelLargeDesktop = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w500,
+    height: 20 / 16,
+    letterSpacing: -0.15,
+  );
+
+  /// Label Medium - Desktop: 12px, Medium, lineHeight: 16, letterSpacing: -0.15
+  static const TextStyle labelMediumDesktop = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.w500,
+    height: 16 / 12,
+    letterSpacing: -0.15,
+  );
+
+  /// Label Small - Desktop: 11px, Medium, lineHeight: 16, letterSpacing: -0.15
+  static const TextStyle labelSmallDesktop = TextStyle(
+    fontSize: 11,
+    fontWeight: FontWeight.w500,
+    height: 16 / 11,
+    letterSpacing: -0.15,
+  );
+
+  /// Body Large - Desktop: 16px, Medium, lineHeight: 24, letterSpacing: -0.15
+  static const TextStyle bodyLargeDesktop = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w500,
+    height: 24 / 16,
+    letterSpacing: -0.15,
+  );
+
+  /// Body Medium - Desktop: 14px, Medium, lineHeight: 20, letterSpacing: -0.15
+  static const TextStyle bodyMediumDesktop = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.w500,
+    height: 20 / 14,
+    letterSpacing: -0.15,
+  );
+
+  /// Body Small - Desktop: 12px, Medium, lineHeight: 16, letterSpacing: -0.15
+  static const TextStyle bodySmallDesktop = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.w500,
+    height: 16 / 12,
+    letterSpacing: -0.15,
+  );
+
+  /// ============ MOBILE TEXT STYLES ============
+
+  /// Display Large - Mobile: 36px, Bold, lineHeight: 44, letterSpacing: -1.5
+  static const TextStyle displayLargeMobile = TextStyle(
+    fontSize: 36,
+    fontWeight: FontWeight.w700,
+    height: 44 / 36,
+    letterSpacing: -1.5,
+  );
+
+  /// Display Medium - Mobile: 32px, Bold, lineHeight: 40, letterSpacing: -1
+  static const TextStyle displayMediumMobile = TextStyle(
+    fontSize: 32,
+    fontWeight: FontWeight.w700,
+    height: 40 / 32,
+    letterSpacing: -1,
+  );
+
+  /// Display Small - Mobile: 28px, Bold, lineHeight: 36, letterSpacing: -1
+  static const TextStyle displaySmallMobile = TextStyle(
+    fontSize: 28,
+    fontWeight: FontWeight.w700,
+    height: 36 / 28,
+    letterSpacing: -1,
+  );
+
+  /// Headline Large - Mobile: 28px, SemiBold, lineHeight: 36, spacing: -1
+  static const TextStyle headlineLargeMobile = TextStyle(
+    fontSize: 28,
+    fontWeight: FontWeight.w600,
+    height: 36 / 28,
+    letterSpacing: -1,
+  );
+
+  /// Headline Medium - Mobile: 22px, SemiBold, lineHeight: 28, spacing: -0.75
+  static const TextStyle headlineMediumMobile = TextStyle(
+    fontSize: 22,
+    fontWeight: FontWeight.w600,
+    height: 28 / 22,
+    letterSpacing: -0.75,
+  );
+
+  /// Headline Small - Mobile: 18px, SemiBold, lineHeight: 24, spacing: -0.5
+  static const TextStyle headlineSmallMobile = TextStyle(
+    fontSize: 18,
+    fontWeight: FontWeight.w600,
+    height: 24 / 18,
+    letterSpacing: -0.5,
+  );
+
+  /// Title Large - Mobile: 20px, Medium, lineHeight: 28, letterSpacing: -0.25
+  static const TextStyle titleLargeMobile = TextStyle(
+    fontSize: 20,
+    fontWeight: FontWeight.w500,
+    height: 28 / 20,
+    letterSpacing: -0.25,
+  );
+
+  /// Title Medium - Mobile: 18px, Medium, lineHeight: 24, letterSpacing: -0.25
+  static const TextStyle titleMediumMobile = TextStyle(
+    fontSize: 18,
+    fontWeight: FontWeight.w500,
+    height: 24 / 18,
+    letterSpacing: -0.25,
+  );
+
+  /// Title Small - Mobile: 14px, Medium, lineHeight: 20, letterSpacing: -0.15
+  static const TextStyle titleSmallMobile = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.w500,
+    height: 20 / 14,
+    letterSpacing: -0.15,
+  );
+
+  /// Label Large - Mobile: 16px, Medium, lineHeight: 20, letterSpacing: -0.15
+  static const TextStyle labelLargeMobile = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w500,
+    height: 20 / 16,
+    letterSpacing: -0.15,
+  );
+
+  /// Label Medium - Mobile: 12px, Medium, lineHeight: 16, letterSpacing: -0.15
+  static const TextStyle labelMediumMobile = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.w500,
+    height: 16 / 12,
+    letterSpacing: -0.15,
+  );
+
+  /// Label Small - Mobile: 11px, Medium, lineHeight: 16, letterSpacing: -0.15
+  static const TextStyle labelSmallMobile = TextStyle(
+    fontSize: 11,
+    fontWeight: FontWeight.w500,
+    height: 16 / 11,
+    letterSpacing: -0.15,
+  );
+
+  /// Body Large - Mobile: 16px, Medium, lineHeight: 20, letterSpacing: -0.15
+  static const TextStyle bodyLargeMobile = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w500,
+    height: 20 / 16,
+    letterSpacing: -0.15,
+  );
+
+  /// Body Medium - Mobile: 14px, Medium, lineHeight: 20, letterSpacing: -0.15
+  static const TextStyle bodyMediumMobile = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.w500,
+    height: 20 / 14,
+    letterSpacing: -0.15,
+  );
+
+  /// Body Small - Mobile: 12px, Medium, lineHeight: 16, letterSpacing: -0.15
+  static const TextStyle bodySmallMobile = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.w500,
+    height: 16 / 12,
+    letterSpacing: -0.15,
+  );
+
+  /// ============ HELPER METHODS ============
+
+  /// Returns the desktop TextTheme
+  static TextTheme get desktopTextTheme => const TextTheme(
+    displayLarge: displayLargeDesktop,
+    displayMedium: displayMediumDesktop,
+    displaySmall: displaySmallDesktop,
+    headlineLarge: headlineLargeDesktop,
+    headlineMedium: headlineMediumDesktop,
+    headlineSmall: headlineSmallDesktop,
+    titleLarge: titleLargeDesktop,
+    titleMedium: titleMediumDesktop,
+    titleSmall: titleSmallDesktop,
+    labelLarge: labelLargeDesktop,
+    labelMedium: labelMediumDesktop,
+    labelSmall: labelSmallDesktop,
+    bodyLarge: bodyLargeDesktop,
+    bodyMedium: bodyMediumDesktop,
+    bodySmall: bodySmallDesktop,
+  );
+
+  /// Returns the mobile TextTheme
+  static TextTheme get mobileTextTheme => const TextTheme(
+    displayLarge: displayLargeMobile,
+    displayMedium: displayMediumMobile,
+    displaySmall: displaySmallMobile,
+    headlineLarge: headlineLargeMobile,
+    headlineMedium: headlineMediumMobile,
+    headlineSmall: headlineSmallMobile,
+    titleLarge: titleLargeMobile,
+    titleMedium: titleMediumMobile,
+    titleSmall: titleSmallMobile,
+    labelLarge: labelLargeMobile,
+    labelMedium: labelMediumMobile,
+    labelSmall: labelSmallMobile,
+    bodyLarge: bodyLargeMobile,
+    bodyMedium: bodyMediumMobile,
+    bodySmall: bodySmallMobile,
+  );
+
+  /// Returns the appropriate TextTheme based on screen width.
+  /// Uses 600px as the breakpoint (same as ResponsiveScaffold).
+  static TextTheme getResponsiveTextTheme(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+    return width >= 600 ? desktopTextTheme : mobileTextTheme;
+  }
+
+  /// ============ THEME EXTENSION ============
+  @override
+  AppTextStyles copyWith() => this;
+
+  @override
+  AppTextStyles lerp(AppTextStyles? other, double t) => this;
+}

--- a/very_good_app_ui/__brick__/lib/src/theme/app_text_styles.dart
+++ b/very_good_app_ui/__brick__/lib/src/theme/app_text_styles.dart
@@ -8,6 +8,9 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   /// {@macro app_text_styles}
   const AppTextStyles();
 
+  // When a custom font is registered in pubspec.yaml, add
+  // `fontFamily: 'YourFontFamily'` to each TextStyle below.
+
   /// ============ DESKTOP TEXT STYLES ============
 
   /// Display Large - Desktop: 48px, Bold, lineHeight: 56, letterSpacing: -2

--- a/very_good_app_ui/__brick__/lib/src/theme/app_text_styles.dart
+++ b/very_good_app_ui/__brick__/lib/src/theme/app_text_styles.dart
@@ -17,7 +17,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle displayLargeDesktop = TextStyle(
     fontSize: 48,
     fontWeight: FontWeight.w700,
-    height: 56 / 48,
+    height: 1.17,
     letterSpacing: -2,
   );
 
@@ -25,7 +25,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle displayMediumDesktop = TextStyle(
     fontSize: 40,
     fontWeight: FontWeight.w700,
-    height: 48 / 40,
+    height: 1.2,
     letterSpacing: -1.5,
   );
 
@@ -33,7 +33,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle displaySmallDesktop = TextStyle(
     fontSize: 36,
     fontWeight: FontWeight.w700,
-    height: 44 / 36,
+    height: 1.22,
     letterSpacing: -1.5,
   );
 
@@ -41,7 +41,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle headlineLargeDesktop = TextStyle(
     fontSize: 32,
     fontWeight: FontWeight.w600,
-    height: 40 / 32,
+    height: 1.25,
     letterSpacing: -1.5,
   );
 
@@ -49,7 +49,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle headlineMediumDesktop = TextStyle(
     fontSize: 24,
     fontWeight: FontWeight.w600,
-    height: 32 / 24,
+    height: 1.33,
     letterSpacing: -1,
   );
 
@@ -57,7 +57,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle headlineSmallDesktop = TextStyle(
     fontSize: 20,
     fontWeight: FontWeight.w600,
-    height: 28 / 20,
+    height: 1.4,
     letterSpacing: -0.75,
   );
 
@@ -65,7 +65,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle titleLargeDesktop = TextStyle(
     fontSize: 24,
     fontWeight: FontWeight.w500,
-    height: 32 / 24,
+    height: 1.33,
     letterSpacing: -0.5,
   );
 
@@ -73,7 +73,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle titleMediumDesktop = TextStyle(
     fontSize: 20,
     fontWeight: FontWeight.w500,
-    height: 28 / 20,
+    height: 1.4,
     letterSpacing: -0.5,
   );
 
@@ -81,7 +81,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle titleSmallDesktop = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.w500,
-    height: 24 / 16,
+    height: 1.5,
     letterSpacing: -0.25,
   );
 
@@ -89,7 +89,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle labelLargeDesktop = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.w500,
-    height: 20 / 16,
+    height: 1.25,
     letterSpacing: -0.15,
   );
 
@@ -97,7 +97,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle labelMediumDesktop = TextStyle(
     fontSize: 12,
     fontWeight: FontWeight.w500,
-    height: 16 / 12,
+    height: 1.33,
     letterSpacing: -0.15,
   );
 
@@ -105,7 +105,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle labelSmallDesktop = TextStyle(
     fontSize: 11,
     fontWeight: FontWeight.w500,
-    height: 16 / 11,
+    height: 1.45,
     letterSpacing: -0.15,
   );
 
@@ -113,7 +113,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle bodyLargeDesktop = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.w500,
-    height: 24 / 16,
+    height: 1.5,
     letterSpacing: -0.15,
   );
 
@@ -121,7 +121,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle bodyMediumDesktop = TextStyle(
     fontSize: 14,
     fontWeight: FontWeight.w500,
-    height: 20 / 14,
+    height: 1.43,
     letterSpacing: -0.15,
   );
 
@@ -129,7 +129,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle bodySmallDesktop = TextStyle(
     fontSize: 12,
     fontWeight: FontWeight.w500,
-    height: 16 / 12,
+    height: 1.33,
     letterSpacing: -0.15,
   );
 
@@ -139,7 +139,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle displayLargeMobile = TextStyle(
     fontSize: 36,
     fontWeight: FontWeight.w700,
-    height: 44 / 36,
+    height: 1.22,
     letterSpacing: -1.5,
   );
 
@@ -147,7 +147,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle displayMediumMobile = TextStyle(
     fontSize: 32,
     fontWeight: FontWeight.w700,
-    height: 40 / 32,
+    height: 1.25,
     letterSpacing: -1,
   );
 
@@ -155,7 +155,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle displaySmallMobile = TextStyle(
     fontSize: 28,
     fontWeight: FontWeight.w700,
-    height: 36 / 28,
+    height: 1.29,
     letterSpacing: -1,
   );
 
@@ -163,7 +163,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle headlineLargeMobile = TextStyle(
     fontSize: 28,
     fontWeight: FontWeight.w600,
-    height: 36 / 28,
+    height: 1.29,
     letterSpacing: -1,
   );
 
@@ -171,7 +171,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle headlineMediumMobile = TextStyle(
     fontSize: 22,
     fontWeight: FontWeight.w600,
-    height: 28 / 22,
+    height: 1.27,
     letterSpacing: -0.75,
   );
 
@@ -179,7 +179,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle headlineSmallMobile = TextStyle(
     fontSize: 18,
     fontWeight: FontWeight.w600,
-    height: 24 / 18,
+    height: 1.33,
     letterSpacing: -0.5,
   );
 
@@ -187,7 +187,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle titleLargeMobile = TextStyle(
     fontSize: 20,
     fontWeight: FontWeight.w500,
-    height: 28 / 20,
+    height: 1.4,
     letterSpacing: -0.25,
   );
 
@@ -195,7 +195,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle titleMediumMobile = TextStyle(
     fontSize: 18,
     fontWeight: FontWeight.w500,
-    height: 24 / 18,
+    height: 1.33,
     letterSpacing: -0.25,
   );
 
@@ -203,7 +203,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle titleSmallMobile = TextStyle(
     fontSize: 14,
     fontWeight: FontWeight.w500,
-    height: 20 / 14,
+    height: 1.43,
     letterSpacing: -0.15,
   );
 
@@ -211,7 +211,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle labelLargeMobile = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.w500,
-    height: 20 / 16,
+    height: 1.25,
     letterSpacing: -0.15,
   );
 
@@ -219,7 +219,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle labelMediumMobile = TextStyle(
     fontSize: 12,
     fontWeight: FontWeight.w500,
-    height: 16 / 12,
+    height: 1.33,
     letterSpacing: -0.15,
   );
 
@@ -227,7 +227,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle labelSmallMobile = TextStyle(
     fontSize: 11,
     fontWeight: FontWeight.w500,
-    height: 16 / 11,
+    height: 1.45,
     letterSpacing: -0.15,
   );
 
@@ -235,7 +235,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle bodyLargeMobile = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.w500,
-    height: 20 / 16,
+    height: 1.25,
     letterSpacing: -0.15,
   );
 
@@ -243,7 +243,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle bodyMediumMobile = TextStyle(
     fontSize: 14,
     fontWeight: FontWeight.w500,
-    height: 20 / 14,
+    height: 1.43,
     letterSpacing: -0.15,
   );
 
@@ -251,7 +251,7 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
   static const TextStyle bodySmallMobile = TextStyle(
     fontSize: 12,
     fontWeight: FontWeight.w500,
-    height: 16 / 12,
+    height: 1.33,
     letterSpacing: -0.15,
   );
 
@@ -297,9 +297,8 @@ class AppTextStyles extends ThemeExtension<AppTextStyles> {
 
   /// Returns the appropriate TextTheme based on screen width.
   /// Uses 600px as the breakpoint (same as ResponsiveScaffold).
-  static TextTheme getResponsiveTextTheme(BuildContext context) {
-    final width = MediaQuery.sizeOf(context).width;
-    return width >= 600 ? desktopTextTheme : mobileTextTheme;
+  static TextTheme getResponsiveTextTheme(double size) {
+    return size >= 600 ? desktopTextTheme : mobileTextTheme;
   }
 
   /// ============ THEME EXTENSION ============

--- a/very_good_app_ui/__brick__/lib/src/theme/app_theme.dart
+++ b/very_good_app_ui/__brick__/lib/src/theme/app_theme.dart
@@ -18,7 +18,7 @@ class AppTheme {
 
     return ThemeData(
       colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF4F46E5)),
-      extensions: const [appColors, AppSpacing()],
+      extensions: const [appColors, AppSpacing(), AppTextStyles()],
     );
   }
 
@@ -38,7 +38,7 @@ class AppTheme {
         seedColor: const Color(0xFF4F46E5),
         brightness: Brightness.dark,
       ),
-      extensions: const [appColors, AppSpacing()],
+      extensions: const [appColors, AppSpacing(), AppTextStyles()],
     );
   }
 }

--- a/very_good_app_ui/__brick__/lib/{{project_name.snakeCase()}}.dart
+++ b/very_good_app_ui/__brick__/lib/{{project_name.snakeCase()}}.dart
@@ -6,5 +6,6 @@ export 'package:flutter/material.dart';
 export 'src/extensions/build_context_extensions.dart';
 export 'src/theme/app_colors.dart';
 export 'src/theme/app_spacing.dart';
+export 'src/theme/app_text_styles.dart';
 export 'src/theme/app_theme.dart';
 export 'src/widgets/app_button.dart';

--- a/very_good_app_ui/__brick__/pubspec.yaml
+++ b/very_good_app_ui/__brick__/pubspec.yaml
@@ -16,3 +16,18 @@ dev_dependencies:
     sdk: flutter
   mocktail: ^1.0.5
   very_good_analysis: ^10.2.0
+
+flutter:
+  fonts:
+    - family: CustomFont
+      fonts:
+        - asset: assets/fonts/CustomFont-Light.ttf
+          weight: 300
+        - asset: assets/fonts/CustomFont-Regular.ttf
+          weight: 400
+        - asset: assets/fonts/CustomFont-Medium.ttf
+          weight: 500
+        - asset: assets/fonts/CustomFont-SemiBold.ttf
+          weight: 600
+        - asset: assets/fonts/CustomFont-Bold.ttf
+          weight: 700

--- a/very_good_app_ui/__brick__/pubspec.yaml
+++ b/very_good_app_ui/__brick__/pubspec.yaml
@@ -17,17 +17,19 @@ dev_dependencies:
   mocktail: ^1.0.5
   very_good_analysis: ^10.2.0
 
-flutter:
-  fonts:
-    - family: CustomFont
-      fonts:
-        - asset: assets/fonts/CustomFont-Light.ttf
-          weight: 300
-        - asset: assets/fonts/CustomFont-Regular.ttf
-          weight: 400
-        - asset: assets/fonts/CustomFont-Medium.ttf
-          weight: 500
-        - asset: assets/fonts/CustomFont-SemiBold.ttf
-          weight: 600
-        - asset: assets/fonts/CustomFont-Bold.ttf
-          weight: 700
+# Uncomment and update the font family name and assets once font files are
+# added under assets/fonts/. Also update AppTextStyles.fontFamily accordingly.
+# flutter:
+#   fonts:
+#     - family: CustomFont
+#       fonts:
+#         - asset: assets/fonts/CustomFont-Light.ttf
+#           weight: 300
+#         - asset: assets/fonts/CustomFont-Regular.ttf
+#           weight: 400
+#         - asset: assets/fonts/CustomFont-Medium.ttf
+#           weight: 500
+#         - asset: assets/fonts/CustomFont-SemiBold.ttf
+#           weight: 600
+#         - asset: assets/fonts/CustomFont-Bold.ttf
+#           weight: 700

--- a/very_good_app_ui/__brick__/pubspec.yaml
+++ b/very_good_app_ui/__brick__/pubspec.yaml
@@ -16,20 +16,3 @@ dev_dependencies:
     sdk: flutter
   mocktail: ^1.0.5
   very_good_analysis: ^10.2.0
-
-# Uncomment and update the font family name and assets once font files are
-# added under assets/fonts/. Also update AppTextStyles.fontFamily accordingly.
-# flutter:
-#   fonts:
-#     - family: CustomFont
-#       fonts:
-#         - asset: assets/fonts/CustomFont-Light.ttf
-#           weight: 300
-#         - asset: assets/fonts/CustomFont-Regular.ttf
-#           weight: 400
-#         - asset: assets/fonts/CustomFont-Medium.ttf
-#           weight: 500
-#         - asset: assets/fonts/CustomFont-SemiBold.ttf
-#           weight: 600
-#         - asset: assets/fonts/CustomFont-Bold.ttf
-#           weight: 700

--- a/very_good_app_ui/__brick__/test/src/extensions/build_context_extensions_test.dart
+++ b/very_good_app_ui/__brick__/test/src/extensions/build_context_extensions_test.dart
@@ -33,7 +33,9 @@ void main() {
       expect(spacing, isA<AppSpacing>());
     });
 
-    testWidgets('appTextStyles returns AppTextStyles from theme', (tester) async {
+    testWidgets('appTextStyles returns AppTextStyles from theme', (
+      tester,
+    ) async {
       late AppTextStyles textStyles;
       await tester.pumpApp(
         Builder(

--- a/very_good_app_ui/__brick__/test/src/extensions/build_context_extensions_test.dart
+++ b/very_good_app_ui/__brick__/test/src/extensions/build_context_extensions_test.dart
@@ -32,5 +32,19 @@ void main() {
 
       expect(spacing, isA<AppSpacing>());
     });
+
+    testWidgets('appTextStyles returns AppTextStyles from theme', (tester) async {
+      late AppTextStyles textStyles;
+      await tester.pumpApp(
+        Builder(
+          builder: (context) {
+            textStyles = context.appTextStyles;
+            return const SizedBox();
+          },
+        ),
+      );
+
+      expect(textStyles, isA<AppTextStyles>());
+    });
   });
 }

--- a/very_good_app_ui/__brick__/test/src/theme/app_text_styles_test.dart
+++ b/very_good_app_ui/__brick__/test/src/theme/app_text_styles_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:{{project_name.snakeCase()}}/{{project_name.snakeCase()}}.dart';
 

--- a/very_good_app_ui/__brick__/test/src/theme/app_text_styles_test.dart
+++ b/very_good_app_ui/__brick__/test/src/theme/app_text_styles_test.dart
@@ -1,0 +1,355 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:{{project_name.snakeCase()}}/{{project_name.snakeCase()}}.dart';
+
+void main() {
+  group('AppTextStyles', () {
+    group('desktop text styles', () {
+      test('displayLargeDesktop has correct values', () {
+        const style = AppTextStyles.displayLargeDesktop;
+        expect(style.fontSize, 48);
+        expect(style.fontWeight, FontWeight.w700);
+        expect(style.height, 56 / 48);
+        expect(style.letterSpacing, -2);
+      });
+
+      test('displayMediumDesktop has correct values', () {
+        const style = AppTextStyles.displayMediumDesktop;
+        expect(style.fontSize, 40);
+        expect(style.fontWeight, FontWeight.w700);
+        expect(style.height, 48 / 40);
+        expect(style.letterSpacing, -1.5);
+      });
+
+      test('displaySmallDesktop has correct values', () {
+        const style = AppTextStyles.displaySmallDesktop;
+        expect(style.fontSize, 36);
+        expect(style.fontWeight, FontWeight.w700);
+        expect(style.height, 44 / 36);
+        expect(style.letterSpacing, -1.5);
+      });
+
+      test('headlineLargeDesktop has correct values', () {
+        const style = AppTextStyles.headlineLargeDesktop;
+        expect(style.fontSize, 32);
+        expect(style.fontWeight, FontWeight.w600);
+        expect(style.height, 40 / 32);
+        expect(style.letterSpacing, -1.5);
+      });
+
+      test('headlineMediumDesktop has correct values', () {
+        const style = AppTextStyles.headlineMediumDesktop;
+        expect(style.fontSize, 24);
+        expect(style.fontWeight, FontWeight.w600);
+        expect(style.height, 32 / 24);
+        expect(style.letterSpacing, -1);
+      });
+
+      test('headlineSmallDesktop has correct values', () {
+        const style = AppTextStyles.headlineSmallDesktop;
+        expect(style.fontSize, 20);
+        expect(style.fontWeight, FontWeight.w600);
+        expect(style.height, 28 / 20);
+        expect(style.letterSpacing, -0.75);
+      });
+
+      test('titleLargeDesktop has correct values', () {
+        const style = AppTextStyles.titleLargeDesktop;
+        expect(style.fontSize, 24);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 32 / 24);
+        expect(style.letterSpacing, -0.5);
+      });
+
+      test('titleMediumDesktop has correct values', () {
+        const style = AppTextStyles.titleMediumDesktop;
+        expect(style.fontSize, 20);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 28 / 20);
+        expect(style.letterSpacing, -0.5);
+      });
+
+      test('titleSmallDesktop has correct values', () {
+        const style = AppTextStyles.titleSmallDesktop;
+        expect(style.fontSize, 16);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 24 / 16);
+        expect(style.letterSpacing, -0.25);
+      });
+
+      test('labelLargeDesktop has correct values', () {
+        const style = AppTextStyles.labelLargeDesktop;
+        expect(style.fontSize, 16);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 20 / 16);
+        expect(style.letterSpacing, -0.15);
+      });
+
+      test('labelMediumDesktop has correct values', () {
+        const style = AppTextStyles.labelMediumDesktop;
+        expect(style.fontSize, 12);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 16 / 12);
+        expect(style.letterSpacing, -0.15);
+      });
+
+      test('labelSmallDesktop has correct values', () {
+        const style = AppTextStyles.labelSmallDesktop;
+        expect(style.fontSize, 11);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 16 / 11);
+        expect(style.letterSpacing, -0.15);
+      });
+
+      test('bodyLargeDesktop has correct values', () {
+        const style = AppTextStyles.bodyLargeDesktop;
+        expect(style.fontSize, 16);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 24 / 16);
+        expect(style.letterSpacing, -0.15);
+      });
+
+      test('bodyMediumDesktop has correct values', () {
+        const style = AppTextStyles.bodyMediumDesktop;
+        expect(style.fontSize, 14);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 20 / 14);
+        expect(style.letterSpacing, -0.15);
+      });
+
+      test('bodySmallDesktop has correct values', () {
+        const style = AppTextStyles.bodySmallDesktop;
+        expect(style.fontSize, 12);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 16 / 12);
+        expect(style.letterSpacing, -0.15);
+      });
+    });
+
+    group('mobile text styles', () {
+      test('displayLargeMobile has correct values', () {
+        const style = AppTextStyles.displayLargeMobile;
+        expect(style.fontSize, 36);
+        expect(style.fontWeight, FontWeight.w700);
+        expect(style.height, 44 / 36);
+        expect(style.letterSpacing, -1.5);
+      });
+
+      test('displayMediumMobile has correct values', () {
+        const style = AppTextStyles.displayMediumMobile;
+        expect(style.fontSize, 32);
+        expect(style.fontWeight, FontWeight.w700);
+        expect(style.height, 40 / 32);
+        expect(style.letterSpacing, -1);
+      });
+
+      test('displaySmallMobile has correct values', () {
+        const style = AppTextStyles.displaySmallMobile;
+        expect(style.fontSize, 28);
+        expect(style.fontWeight, FontWeight.w700);
+        expect(style.height, 36 / 28);
+        expect(style.letterSpacing, -1);
+      });
+
+      test('headlineLargeMobile has correct values', () {
+        const style = AppTextStyles.headlineLargeMobile;
+        expect(style.fontSize, 28);
+        expect(style.fontWeight, FontWeight.w600);
+        expect(style.height, 36 / 28);
+        expect(style.letterSpacing, -1);
+      });
+
+      test('headlineMediumMobile has correct values', () {
+        const style = AppTextStyles.headlineMediumMobile;
+        expect(style.fontSize, 22);
+        expect(style.fontWeight, FontWeight.w600);
+        expect(style.height, 28 / 22);
+        expect(style.letterSpacing, -0.75);
+      });
+
+      test('headlineSmallMobile has correct values', () {
+        const style = AppTextStyles.headlineSmallMobile;
+        expect(style.fontSize, 18);
+        expect(style.fontWeight, FontWeight.w600);
+        expect(style.height, 24 / 18);
+        expect(style.letterSpacing, -0.5);
+      });
+
+      test('titleLargeMobile has correct values', () {
+        const style = AppTextStyles.titleLargeMobile;
+        expect(style.fontSize, 20);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 28 / 20);
+        expect(style.letterSpacing, -0.25);
+      });
+
+      test('titleMediumMobile has correct values', () {
+        const style = AppTextStyles.titleMediumMobile;
+        expect(style.fontSize, 18);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 24 / 18);
+        expect(style.letterSpacing, -0.25);
+      });
+
+      test('titleSmallMobile has correct values', () {
+        const style = AppTextStyles.titleSmallMobile;
+        expect(style.fontSize, 14);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 20 / 14);
+        expect(style.letterSpacing, -0.15);
+      });
+
+      test('labelLargeMobile has correct values', () {
+        const style = AppTextStyles.labelLargeMobile;
+        expect(style.fontSize, 16);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 20 / 16);
+        expect(style.letterSpacing, -0.15);
+      });
+
+      test('labelMediumMobile has correct values', () {
+        const style = AppTextStyles.labelMediumMobile;
+        expect(style.fontSize, 12);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 16 / 12);
+        expect(style.letterSpacing, -0.15);
+      });
+
+      test('labelSmallMobile has correct values', () {
+        const style = AppTextStyles.labelSmallMobile;
+        expect(style.fontSize, 11);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 16 / 11);
+        expect(style.letterSpacing, -0.15);
+      });
+
+      test('bodyLargeMobile has correct values', () {
+        const style = AppTextStyles.bodyLargeMobile;
+        expect(style.fontSize, 16);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 20 / 16);
+        expect(style.letterSpacing, -0.15);
+      });
+
+      test('bodyMediumMobile has correct values', () {
+        const style = AppTextStyles.bodyMediumMobile;
+        expect(style.fontSize, 14);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 20 / 14);
+        expect(style.letterSpacing, -0.15);
+      });
+
+      test('bodySmallMobile has correct values', () {
+        const style = AppTextStyles.bodySmallMobile;
+        expect(style.fontSize, 12);
+        expect(style.fontWeight, FontWeight.w500);
+        expect(style.height, 16 / 12);
+        expect(style.letterSpacing, -0.15);
+      });
+    });
+
+    group('desktopTextTheme', () {
+      test('maps each slot to the correct desktop style', () {
+        final textTheme = AppTextStyles.desktopTextTheme;
+        expect(textTheme.displayLarge, AppTextStyles.displayLargeDesktop);
+        expect(textTheme.displayMedium, AppTextStyles.displayMediumDesktop);
+        expect(textTheme.displaySmall, AppTextStyles.displaySmallDesktop);
+        expect(textTheme.headlineLarge, AppTextStyles.headlineLargeDesktop);
+        expect(textTheme.headlineMedium, AppTextStyles.headlineMediumDesktop);
+        expect(textTheme.headlineSmall, AppTextStyles.headlineSmallDesktop);
+        expect(textTheme.titleLarge, AppTextStyles.titleLargeDesktop);
+        expect(textTheme.titleMedium, AppTextStyles.titleMediumDesktop);
+        expect(textTheme.titleSmall, AppTextStyles.titleSmallDesktop);
+        expect(textTheme.labelLarge, AppTextStyles.labelLargeDesktop);
+        expect(textTheme.labelMedium, AppTextStyles.labelMediumDesktop);
+        expect(textTheme.labelSmall, AppTextStyles.labelSmallDesktop);
+        expect(textTheme.bodyLarge, AppTextStyles.bodyLargeDesktop);
+        expect(textTheme.bodyMedium, AppTextStyles.bodyMediumDesktop);
+        expect(textTheme.bodySmall, AppTextStyles.bodySmallDesktop);
+      });
+    });
+
+    group('mobileTextTheme', () {
+      test('maps each slot to the correct mobile style', () {
+        final textTheme = AppTextStyles.mobileTextTheme;
+        expect(textTheme.displayLarge, AppTextStyles.displayLargeMobile);
+        expect(textTheme.displayMedium, AppTextStyles.displayMediumMobile);
+        expect(textTheme.displaySmall, AppTextStyles.displaySmallMobile);
+        expect(textTheme.headlineLarge, AppTextStyles.headlineLargeMobile);
+        expect(textTheme.headlineMedium, AppTextStyles.headlineMediumMobile);
+        expect(textTheme.headlineSmall, AppTextStyles.headlineSmallMobile);
+        expect(textTheme.titleLarge, AppTextStyles.titleLargeMobile);
+        expect(textTheme.titleMedium, AppTextStyles.titleMediumMobile);
+        expect(textTheme.titleSmall, AppTextStyles.titleSmallMobile);
+        expect(textTheme.labelLarge, AppTextStyles.labelLargeMobile);
+        expect(textTheme.labelMedium, AppTextStyles.labelMediumMobile);
+        expect(textTheme.labelSmall, AppTextStyles.labelSmallMobile);
+        expect(textTheme.bodyLarge, AppTextStyles.bodyLargeMobile);
+        expect(textTheme.bodyMedium, AppTextStyles.bodyMediumMobile);
+        expect(textTheme.bodySmall, AppTextStyles.bodySmallMobile);
+      });
+    });
+
+    group('getResponsiveTextTheme', () {
+      testWidgets('returns mobileTextTheme when width is below 600', (
+        tester,
+      ) async {
+        late TextTheme result;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: MediaQuery(
+              data: const MediaQueryData(size: Size(599, 800)),
+              child: Builder(
+                builder: (context) {
+                  result = AppTextStyles.getResponsiveTextTheme(context);
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          ),
+        );
+        expect(result, AppTextStyles.mobileTextTheme);
+      });
+
+      testWidgets('returns desktopTextTheme when width is exactly 600', (
+        tester,
+      ) async {
+        late TextTheme result;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: MediaQuery(
+              data: const MediaQueryData(size: Size(600, 800)),
+              child: Builder(
+                builder: (context) {
+                  result = AppTextStyles.getResponsiveTextTheme(context);
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          ),
+        );
+        expect(result, AppTextStyles.desktopTextTheme);
+      });
+
+      testWidgets('returns desktopTextTheme when width is above 600', (
+        tester,
+      ) async {
+        late TextTheme result;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: MediaQuery(
+              data: const MediaQueryData(size: Size(1024, 768)),
+              child: Builder(
+                builder: (context) {
+                  result = AppTextStyles.getResponsiveTextTheme(context);
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          ),
+        );
+        expect(result, AppTextStyles.desktopTextTheme);
+      });
+    });
+  });
+}

--- a/very_good_app_ui/__brick__/test/src/theme/app_text_styles_test.dart
+++ b/very_good_app_ui/__brick__/test/src/theme/app_text_styles_test.dart
@@ -3,7 +3,7 @@ import 'package:{{project_name.snakeCase()}}/{{project_name.snakeCase()}}.dart';
 
 void main() {
   group('AppTextStyles', () {
-      group('desktop text styles', () {
+    group('desktop text styles', () {
       test('displayLargeDesktop has correct values', () {
         const style = AppTextStyles.displayLargeDesktop;
         expect(style.fontSize, 48);

--- a/very_good_app_ui/__brick__/test/src/theme/app_text_styles_test.dart
+++ b/very_good_app_ui/__brick__/test/src/theme/app_text_styles_test.dart
@@ -3,7 +3,7 @@ import 'package:{{project_name.snakeCase()}}/{{project_name.snakeCase()}}.dart';
 
 void main() {
   group('AppTextStyles', () {
-    group('desktop text styles', () {
+      group('desktop text styles', () {
       test('displayLargeDesktop has correct values', () {
         const style = AppTextStyles.displayLargeDesktop;
         expect(style.fontSize, 48);

--- a/very_good_app_ui/__brick__/test/src/theme/app_text_styles_test.dart
+++ b/very_good_app_ui/__brick__/test/src/theme/app_text_styles_test.dart
@@ -6,244 +6,244 @@ void main() {
     group('desktop text styles', () {
       test('displayLargeDesktop has correct values', () {
         const style = AppTextStyles.displayLargeDesktop;
-        expect(style.fontSize, 48);
-        expect(style.fontWeight, FontWeight.w700);
-        expect(style.height, equals(1.17));
-        expect(style.letterSpacing, equals(-2));
+        expect(style.fontSize, equals(48));
+        expect(style.fontWeight, equals(FontWeight.w700));
+        expect(style.height, 1.17);
+        expect(style.letterSpacing, -2);
       });
 
       test('displayMediumDesktop has correct values', () {
         const style = AppTextStyles.displayMediumDesktop;
-        expect(style.fontSize, 40);
-        expect(style.fontWeight, FontWeight.w700);
-        expect(style.height, equals(1.2));
-        expect(style.letterSpacing, equals(-1.5));
+        expect(style.fontSize, equals(40));
+        expect(style.fontWeight, equals(FontWeight.w700));
+        expect(style.height, 1.2);
+        expect(style.letterSpacing, -1.5);
       });
 
       test('displaySmallDesktop has correct values', () {
         const style = AppTextStyles.displaySmallDesktop;
-        expect(style.fontSize, 36);
-        expect(style.fontWeight, FontWeight.w700);
-        expect(style.height, equals(1.22));
-        expect(style.letterSpacing, equals(-1.5));
+        expect(style.fontSize, equals(36));
+        expect(style.fontWeight, equals(FontWeight.w700));
+        expect(style.height, 1.22);
+        expect(style.letterSpacing, -1.5);
       });
 
       test('headlineLargeDesktop has correct values', () {
         const style = AppTextStyles.headlineLargeDesktop;
-        expect(style.fontSize, 32);
-        expect(style.fontWeight, FontWeight.w600);
-        expect(style.height, equals(1.25));
-        expect(style.letterSpacing, equals(-1.5));
+        expect(style.fontSize, equals(32));
+        expect(style.fontWeight, equals(FontWeight.w600));
+        expect(style.height, 1.25);
+        expect(style.letterSpacing, -1.5);
       });
 
       test('headlineMediumDesktop has correct values', () {
         const style = AppTextStyles.headlineMediumDesktop;
-        expect(style.fontSize, 24);
-        expect(style.fontWeight, FontWeight.w600);
-        expect(style.height, equals(1.33));
-        expect(style.letterSpacing, equals(-1));
+        expect(style.fontSize, equals(24));
+        expect(style.fontWeight, equals(FontWeight.w600));
+        expect(style.height, 1.33);
+        expect(style.letterSpacing, -1);
       });
 
       test('headlineSmallDesktop has correct values', () {
         const style = AppTextStyles.headlineSmallDesktop;
-        expect(style.fontSize, 20);
-        expect(style.fontWeight, FontWeight.w600);
-        expect(style.height, equals(1.4));
-        expect(style.letterSpacing, equals(-0.75));
+        expect(style.fontSize, equals(20));
+        expect(style.fontWeight, equals(FontWeight.w600));
+        expect(style.height, 1.4);
+        expect(style.letterSpacing, -0.75);
       });
 
       test('titleLargeDesktop has correct values', () {
         const style = AppTextStyles.titleLargeDesktop;
-        expect(style.fontSize, 24);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.33));
-        expect(style.letterSpacing, equals(-0.5));
+        expect(style.fontSize, equals(24));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.33);
+        expect(style.letterSpacing, -0.5);
       });
 
       test('titleMediumDesktop has correct values', () {
         const style = AppTextStyles.titleMediumDesktop;
-        expect(style.fontSize, 20);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.4));
-        expect(style.letterSpacing, equals(-0.5));
+        expect(style.fontSize, equals(20));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.4);
+        expect(style.letterSpacing, -0.5);
       });
 
       test('titleSmallDesktop has correct values', () {
         const style = AppTextStyles.titleSmallDesktop;
-        expect(style.fontSize, 16);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.5));
-        expect(style.letterSpacing, equals(-0.25));
+        expect(style.fontSize, equals(16));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.5);
+        expect(style.letterSpacing, -0.25);
       });
 
       test('labelLargeDesktop has correct values', () {
         const style = AppTextStyles.labelLargeDesktop;
-        expect(style.fontSize, 16);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.25));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(16));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.25);
+        expect(style.letterSpacing, -0.15);
       });
 
       test('labelMediumDesktop has correct values', () {
         const style = AppTextStyles.labelMediumDesktop;
-        expect(style.fontSize, 12);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.33));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(12));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.33);
+        expect(style.letterSpacing, -0.15);
       });
 
       test('labelSmallDesktop has correct values', () {
         const style = AppTextStyles.labelSmallDesktop;
-        expect(style.fontSize, 11);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.45));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(11));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.45);
+        expect(style.letterSpacing, -0.15);
       });
 
       test('bodyLargeDesktop has correct values', () {
         const style = AppTextStyles.bodyLargeDesktop;
-        expect(style.fontSize, 16);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.5));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(16));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.5);
+        expect(style.letterSpacing, -0.15);
       });
 
       test('bodyMediumDesktop has correct values', () {
         const style = AppTextStyles.bodyMediumDesktop;
-        expect(style.fontSize, 14);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.43));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(14));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.43);
+        expect(style.letterSpacing, -0.15);
       });
 
       test('bodySmallDesktop has correct values', () {
         const style = AppTextStyles.bodySmallDesktop;
-        expect(style.fontSize, 12);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.33));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(12));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.33);
+        expect(style.letterSpacing, -0.15);
       });
     });
 
     group('mobile text styles', () {
       test('displayLargeMobile has correct values', () {
         const style = AppTextStyles.displayLargeMobile;
-        expect(style.fontSize, 36);
-        expect(style.fontWeight, FontWeight.w700);
-        expect(style.height, equals(1.22));
-        expect(style.letterSpacing, equals(-1.5));
+        expect(style.fontSize, equals(36));
+        expect(style.fontWeight, equals(FontWeight.w700));
+        expect(style.height, 1.22);
+        expect(style.letterSpacing, -1.5);
       });
 
       test('displayMediumMobile has correct values', () {
         const style = AppTextStyles.displayMediumMobile;
-        expect(style.fontSize, 32);
-        expect(style.fontWeight, FontWeight.w700);
-        expect(style.height, equals(1.25));
-        expect(style.letterSpacing, equals(-1));
+        expect(style.fontSize, equals(32));
+        expect(style.fontWeight, equals(FontWeight.w700));
+        expect(style.height, 1.25);
+        expect(style.letterSpacing, -1);
       });
 
       test('displaySmallMobile has correct values', () {
         const style = AppTextStyles.displaySmallMobile;
-        expect(style.fontSize, 28);
-        expect(style.fontWeight, FontWeight.w700);
-        expect(style.height, equals(1.29));
-        expect(style.letterSpacing, equals(-1));
+        expect(style.fontSize, equals(28));
+        expect(style.fontWeight, equals(FontWeight.w700));
+        expect(style.height, 1.29);
+        expect(style.letterSpacing, -1);
       });
 
       test('headlineLargeMobile has correct values', () {
         const style = AppTextStyles.headlineLargeMobile;
-        expect(style.fontSize, 28);
-        expect(style.fontWeight, FontWeight.w600);
-        expect(style.height, equals(1.29));
-        expect(style.letterSpacing, equals(-1));
+        expect(style.fontSize, equals(28));
+        expect(style.fontWeight, equals(FontWeight.w600));
+        expect(style.height, 1.29);
+        expect(style.letterSpacing, -1);
       });
 
       test('headlineMediumMobile has correct values', () {
         const style = AppTextStyles.headlineMediumMobile;
-        expect(style.fontSize, 22);
-        expect(style.fontWeight, FontWeight.w600);
-        expect(style.height, equals(1.27));
-        expect(style.letterSpacing, equals(-0.75));
+        expect(style.fontSize, equals(22));
+        expect(style.fontWeight, equals(FontWeight.w600));
+        expect(style.height, 1.27);
+        expect(style.letterSpacing, -0.75);
       });
 
       test('headlineSmallMobile has correct values', () {
         const style = AppTextStyles.headlineSmallMobile;
-        expect(style.fontSize, 18);
-        expect(style.fontWeight, FontWeight.w600);
-        expect(style.height, equals(1.33));
-        expect(style.letterSpacing, equals(-0.5));
+        expect(style.fontSize, equals(18));
+        expect(style.fontWeight, equals(FontWeight.w600));
+        expect(style.height, 1.33);
+        expect(style.letterSpacing, -0.5);
       });
 
       test('titleLargeMobile has correct values', () {
         const style = AppTextStyles.titleLargeMobile;
-        expect(style.fontSize, 20);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.4));
-        expect(style.letterSpacing, equals(-0.25));
+        expect(style.fontSize, equals(20));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.4);
+        expect(style.letterSpacing, -0.25);
       });
 
       test('titleMediumMobile has correct values', () {
         const style = AppTextStyles.titleMediumMobile;
-        expect(style.fontSize, 18);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.33));
-        expect(style.letterSpacing, equals(-0.25));
+        expect(style.fontSize, equals(18));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.33);
+        expect(style.letterSpacing, -0.25);
       });
 
       test('titleSmallMobile has correct values', () {
         const style = AppTextStyles.titleSmallMobile;
-        expect(style.fontSize, 14);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.43));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(14));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.43);
+        expect(style.letterSpacing, -0.15);
       });
 
       test('labelLargeMobile has correct values', () {
         const style = AppTextStyles.labelLargeMobile;
-        expect(style.fontSize, 16);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.25));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(16));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.25);
+        expect(style.letterSpacing, -0.15);
       });
 
       test('labelMediumMobile has correct values', () {
         const style = AppTextStyles.labelMediumMobile;
-        expect(style.fontSize, 12);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.33));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(12));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.33);
+        expect(style.letterSpacing, -0.15);
       });
 
       test('labelSmallMobile has correct values', () {
         const style = AppTextStyles.labelSmallMobile;
-        expect(style.fontSize, 11);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.45));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(11));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.45);
+        expect(style.letterSpacing, -0.15);
       });
 
       test('bodyLargeMobile has correct values', () {
         const style = AppTextStyles.bodyLargeMobile;
-        expect(style.fontSize, 16);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.25));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(16));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.25);
+        expect(style.letterSpacing, -0.15);
       });
 
       test('bodyMediumMobile has correct values', () {
         const style = AppTextStyles.bodyMediumMobile;
-        expect(style.fontSize, 14);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.43));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(14));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.43);
+        expect(style.letterSpacing, -0.15);
       });
 
       test('bodySmallMobile has correct values', () {
         const style = AppTextStyles.bodySmallMobile;
-        expect(style.fontSize, 12);
-        expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, equals(1.33));
-        expect(style.letterSpacing, equals(-0.15));
+        expect(style.fontSize, equals(12));
+        expect(style.fontWeight, equals(FontWeight.w500));
+        expect(style.height, 1.33);
+        expect(style.letterSpacing, -0.15);
       });
     });
 

--- a/very_good_app_ui/__brick__/test/src/theme/app_text_styles_test.dart
+++ b/very_good_app_ui/__brick__/test/src/theme/app_text_styles_test.dart
@@ -8,120 +8,120 @@ void main() {
         const style = AppTextStyles.displayLargeDesktop;
         expect(style.fontSize, 48);
         expect(style.fontWeight, FontWeight.w700);
-        expect(style.height, 56 / 48);
-        expect(style.letterSpacing, -2);
+        expect(style.height, equals(1.17));
+        expect(style.letterSpacing, equals(-2));
       });
 
       test('displayMediumDesktop has correct values', () {
         const style = AppTextStyles.displayMediumDesktop;
         expect(style.fontSize, 40);
         expect(style.fontWeight, FontWeight.w700);
-        expect(style.height, 48 / 40);
-        expect(style.letterSpacing, -1.5);
+        expect(style.height, equals(1.2));
+        expect(style.letterSpacing, equals(-1.5));
       });
 
       test('displaySmallDesktop has correct values', () {
         const style = AppTextStyles.displaySmallDesktop;
         expect(style.fontSize, 36);
         expect(style.fontWeight, FontWeight.w700);
-        expect(style.height, 44 / 36);
-        expect(style.letterSpacing, -1.5);
+        expect(style.height, equals(1.22));
+        expect(style.letterSpacing, equals(-1.5));
       });
 
       test('headlineLargeDesktop has correct values', () {
         const style = AppTextStyles.headlineLargeDesktop;
         expect(style.fontSize, 32);
         expect(style.fontWeight, FontWeight.w600);
-        expect(style.height, 40 / 32);
-        expect(style.letterSpacing, -1.5);
+        expect(style.height, equals(1.25));
+        expect(style.letterSpacing, equals(-1.5));
       });
 
       test('headlineMediumDesktop has correct values', () {
         const style = AppTextStyles.headlineMediumDesktop;
         expect(style.fontSize, 24);
         expect(style.fontWeight, FontWeight.w600);
-        expect(style.height, 32 / 24);
-        expect(style.letterSpacing, -1);
+        expect(style.height, equals(1.33));
+        expect(style.letterSpacing, equals(-1));
       });
 
       test('headlineSmallDesktop has correct values', () {
         const style = AppTextStyles.headlineSmallDesktop;
         expect(style.fontSize, 20);
         expect(style.fontWeight, FontWeight.w600);
-        expect(style.height, 28 / 20);
-        expect(style.letterSpacing, -0.75);
+        expect(style.height, equals(1.4));
+        expect(style.letterSpacing, equals(-0.75));
       });
 
       test('titleLargeDesktop has correct values', () {
         const style = AppTextStyles.titleLargeDesktop;
         expect(style.fontSize, 24);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 32 / 24);
-        expect(style.letterSpacing, -0.5);
+        expect(style.height, equals(1.33));
+        expect(style.letterSpacing, equals(-0.5));
       });
 
       test('titleMediumDesktop has correct values', () {
         const style = AppTextStyles.titleMediumDesktop;
         expect(style.fontSize, 20);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 28 / 20);
-        expect(style.letterSpacing, -0.5);
+        expect(style.height, equals(1.4));
+        expect(style.letterSpacing, equals(-0.5));
       });
 
       test('titleSmallDesktop has correct values', () {
         const style = AppTextStyles.titleSmallDesktop;
         expect(style.fontSize, 16);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 24 / 16);
-        expect(style.letterSpacing, -0.25);
+        expect(style.height, equals(1.5));
+        expect(style.letterSpacing, equals(-0.25));
       });
 
       test('labelLargeDesktop has correct values', () {
         const style = AppTextStyles.labelLargeDesktop;
         expect(style.fontSize, 16);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 20 / 16);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.25));
+        expect(style.letterSpacing, equals(-0.15));
       });
 
       test('labelMediumDesktop has correct values', () {
         const style = AppTextStyles.labelMediumDesktop;
         expect(style.fontSize, 12);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 16 / 12);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.33));
+        expect(style.letterSpacing, equals(-0.15));
       });
 
       test('labelSmallDesktop has correct values', () {
         const style = AppTextStyles.labelSmallDesktop;
         expect(style.fontSize, 11);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 16 / 11);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.45));
+        expect(style.letterSpacing, equals(-0.15));
       });
 
       test('bodyLargeDesktop has correct values', () {
         const style = AppTextStyles.bodyLargeDesktop;
         expect(style.fontSize, 16);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 24 / 16);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.5));
+        expect(style.letterSpacing, equals(-0.15));
       });
 
       test('bodyMediumDesktop has correct values', () {
         const style = AppTextStyles.bodyMediumDesktop;
         expect(style.fontSize, 14);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 20 / 14);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.43));
+        expect(style.letterSpacing, equals(-0.15));
       });
 
       test('bodySmallDesktop has correct values', () {
         const style = AppTextStyles.bodySmallDesktop;
         expect(style.fontSize, 12);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 16 / 12);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.33));
+        expect(style.letterSpacing, equals(-0.15));
       });
     });
 
@@ -130,120 +130,120 @@ void main() {
         const style = AppTextStyles.displayLargeMobile;
         expect(style.fontSize, 36);
         expect(style.fontWeight, FontWeight.w700);
-        expect(style.height, 44 / 36);
-        expect(style.letterSpacing, -1.5);
+        expect(style.height, equals(1.22));
+        expect(style.letterSpacing, equals(-1.5));
       });
 
       test('displayMediumMobile has correct values', () {
         const style = AppTextStyles.displayMediumMobile;
         expect(style.fontSize, 32);
         expect(style.fontWeight, FontWeight.w700);
-        expect(style.height, 40 / 32);
-        expect(style.letterSpacing, -1);
+        expect(style.height, equals(1.25));
+        expect(style.letterSpacing, equals(-1));
       });
 
       test('displaySmallMobile has correct values', () {
         const style = AppTextStyles.displaySmallMobile;
         expect(style.fontSize, 28);
         expect(style.fontWeight, FontWeight.w700);
-        expect(style.height, 36 / 28);
-        expect(style.letterSpacing, -1);
+        expect(style.height, equals(1.29));
+        expect(style.letterSpacing, equals(-1));
       });
 
       test('headlineLargeMobile has correct values', () {
         const style = AppTextStyles.headlineLargeMobile;
         expect(style.fontSize, 28);
         expect(style.fontWeight, FontWeight.w600);
-        expect(style.height, 36 / 28);
-        expect(style.letterSpacing, -1);
+        expect(style.height, equals(1.29));
+        expect(style.letterSpacing, equals(-1));
       });
 
       test('headlineMediumMobile has correct values', () {
         const style = AppTextStyles.headlineMediumMobile;
         expect(style.fontSize, 22);
         expect(style.fontWeight, FontWeight.w600);
-        expect(style.height, 28 / 22);
-        expect(style.letterSpacing, -0.75);
+        expect(style.height, equals(1.27));
+        expect(style.letterSpacing, equals(-0.75));
       });
 
       test('headlineSmallMobile has correct values', () {
         const style = AppTextStyles.headlineSmallMobile;
         expect(style.fontSize, 18);
         expect(style.fontWeight, FontWeight.w600);
-        expect(style.height, 24 / 18);
-        expect(style.letterSpacing, -0.5);
+        expect(style.height, equals(1.33));
+        expect(style.letterSpacing, equals(-0.5));
       });
 
       test('titleLargeMobile has correct values', () {
         const style = AppTextStyles.titleLargeMobile;
         expect(style.fontSize, 20);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 28 / 20);
-        expect(style.letterSpacing, -0.25);
+        expect(style.height, equals(1.4));
+        expect(style.letterSpacing, equals(-0.25));
       });
 
       test('titleMediumMobile has correct values', () {
         const style = AppTextStyles.titleMediumMobile;
         expect(style.fontSize, 18);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 24 / 18);
-        expect(style.letterSpacing, -0.25);
+        expect(style.height, equals(1.33));
+        expect(style.letterSpacing, equals(-0.25));
       });
 
       test('titleSmallMobile has correct values', () {
         const style = AppTextStyles.titleSmallMobile;
         expect(style.fontSize, 14);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 20 / 14);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.43));
+        expect(style.letterSpacing, equals(-0.15));
       });
 
       test('labelLargeMobile has correct values', () {
         const style = AppTextStyles.labelLargeMobile;
         expect(style.fontSize, 16);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 20 / 16);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.25));
+        expect(style.letterSpacing, equals(-0.15));
       });
 
       test('labelMediumMobile has correct values', () {
         const style = AppTextStyles.labelMediumMobile;
         expect(style.fontSize, 12);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 16 / 12);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.33));
+        expect(style.letterSpacing, equals(-0.15));
       });
 
       test('labelSmallMobile has correct values', () {
         const style = AppTextStyles.labelSmallMobile;
         expect(style.fontSize, 11);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 16 / 11);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.45));
+        expect(style.letterSpacing, equals(-0.15));
       });
 
       test('bodyLargeMobile has correct values', () {
         const style = AppTextStyles.bodyLargeMobile;
         expect(style.fontSize, 16);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 20 / 16);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.25));
+        expect(style.letterSpacing, equals(-0.15));
       });
 
       test('bodyMediumMobile has correct values', () {
         const style = AppTextStyles.bodyMediumMobile;
         expect(style.fontSize, 14);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 20 / 14);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.43));
+        expect(style.letterSpacing, equals(-0.15));
       });
 
       test('bodySmallMobile has correct values', () {
         const style = AppTextStyles.bodySmallMobile;
         expect(style.fontSize, 12);
         expect(style.fontWeight, FontWeight.w500);
-        expect(style.height, 16 / 12);
-        expect(style.letterSpacing, -0.15);
+        expect(style.height, equals(1.33));
+        expect(style.letterSpacing, equals(-0.15));
       });
     });
 
@@ -290,64 +290,25 @@ void main() {
     });
 
     group('getResponsiveTextTheme', () {
-      testWidgets('returns mobileTextTheme when width is below 600', (
-        tester,
-      ) async {
-        late TextTheme result;
-        await tester.pumpWidget(
-          MaterialApp(
-            home: MediaQuery(
-              data: const MediaQueryData(size: Size(599, 800)),
-              child: Builder(
-                builder: (context) {
-                  result = AppTextStyles.getResponsiveTextTheme(context);
-                  return const SizedBox.shrink();
-                },
-              ),
-            ),
-          ),
+      test('returns mobileTextTheme when width is below 600', () {
+        expect(
+          AppTextStyles.getResponsiveTextTheme(599),
+          AppTextStyles.mobileTextTheme,
         );
-        expect(result, AppTextStyles.mobileTextTheme);
       });
 
-      testWidgets('returns desktopTextTheme when width is exactly 600', (
-        tester,
-      ) async {
-        late TextTheme result;
-        await tester.pumpWidget(
-          MaterialApp(
-            home: MediaQuery(
-              data: const MediaQueryData(size: Size(600, 800)),
-              child: Builder(
-                builder: (context) {
-                  result = AppTextStyles.getResponsiveTextTheme(context);
-                  return const SizedBox.shrink();
-                },
-              ),
-            ),
-          ),
+      test('returns desktopTextTheme when width is exactly 600', () {
+        expect(
+          AppTextStyles.getResponsiveTextTheme(600),
+          AppTextStyles.desktopTextTheme,
         );
-        expect(result, AppTextStyles.desktopTextTheme);
       });
 
-      testWidgets('returns desktopTextTheme when width is above 600', (
-        tester,
-      ) async {
-        late TextTheme result;
-        await tester.pumpWidget(
-          MaterialApp(
-            home: MediaQuery(
-              data: const MediaQueryData(size: Size(1024, 768)),
-              child: Builder(
-                builder: (context) {
-                  result = AppTextStyles.getResponsiveTextTheme(context);
-                  return const SizedBox.shrink();
-                },
-              ),
-            ),
-          ),
+      test('returns desktopTextTheme when width is above 600', () {
+        expect(
+          AppTextStyles.getResponsiveTextTheme(1024),
+          AppTextStyles.desktopTextTheme,
         );
-        expect(result, AppTextStyles.desktopTextTheme);
       });
     });
   });

--- a/very_good_app_ui/__brick__/test/src/theme/app_theme_test.dart
+++ b/very_good_app_ui/__brick__/test/src/theme/app_theme_test.dart
@@ -16,6 +16,10 @@ void main() {
         expect(AppTheme.light.extension<AppSpacing>(), isNotNull);
       });
 
+      test('has AppTextStyles extension', () {
+        expect(AppTheme.light.extension<AppTextStyles>(), isNotNull);
+      });
+
       test('has light brightness', () {
         expect(AppTheme.light.brightness, Brightness.light);
       });
@@ -32,6 +36,10 @@ void main() {
 
       test('has AppSpacing extension', () {
         expect(AppTheme.dark.extension<AppSpacing>(), isNotNull);
+      });
+
+      test('has AppTextStyles extension', () {
+        expect(AppTheme.dark.extension<AppTextStyles>(), isNotNull);
       });
 
       test('has dark brightness', () {


### PR DESCRIPTION
## Description

- Add `AppTextStyles` with desktop and mobile static `TextStyle` constants covering the Material 3 type scale
- Add `desktopTextTheme`, `mobileTextTheme` getters and a `getResponsiveTextTheme(BuildContext)` helper (with a defined breakpoint)
- Register `AppTextStyles` as a `ThemeExtension` in both light and dark `AppTheme`
- Add test coverage

### Issue #521 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [X] 🧪 Test
